### PR TITLE
Feature/28 extend layer stack abstraction

### DIFF
--- a/Cory/CMakeLists.txt
+++ b/Cory/CMakeLists.txt
@@ -89,7 +89,7 @@ set(CORY_SOURCES
         src/Renderer/Synchronization.cpp
         src/Renderer/UniformBufferObject.cpp
         src/Renderer/VulkanUtils.cpp
-        include/Cory/Application/ApplicationLayer.hpp include/Cory/Application/Event.hpp include/Cory/Base/Random.hpp)
+        include/Cory/Application/ApplicationLayer.hpp include/Cory/Application/Event.hpp include/Cory/Base/Random.hpp include/Cory/Application/LayerStack.hpp src/Application/LayerStack.cpp)
 
 file(GLOB_RECURSE HEADERS "include/*.h")
 

--- a/Cory/include/Cory/Application/Application.hpp
+++ b/Cory/include/Cory/Application/Application.hpp
@@ -1,11 +1,30 @@
 #pragma once
 
+#include <Cory/Application/Common.hpp>
+#include <Cory/Base/Common.hpp>
+#include <Cory/Renderer/Common.hpp>
+
+#include <memory>
+
 namespace Cory {
 
-class Application {
+class Application : NoCopy, NoMove {
   public:
+    Application();
+    virtual ~Application();
+
     virtual void run() = 0;
 
+    void init(const ContextCreationInfo &info);
+
+    Context& ctx();
+    const Context& ctx() const;
+
+    LayerStack &layers();
+    const LayerStack &layers() const;
+
+  private:
+    std::unique_ptr<struct ApplicationPrivate> data_;
 };
 
 } // namespace Cory

--- a/Cory/include/Cory/Application/Common.hpp
+++ b/Cory/include/Cory/Application/Common.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <glm/vec2.hpp>
+
+#include <stdint.h>
+
+#include <Cory/Framegraph/Common.hpp>
+
 // forward-declare so we can declare our namespace alias here
 namespace KDBindings {
 } // namespace KDBindings
@@ -8,6 +14,20 @@ namespace kdb = KDBindings;
 namespace Cory {
 class Window;
 class Application;
+class LayerStack;
+class ApplicationLayer;
+
+/// data to be passed to a layer when it is attached
+struct LayerAttachInfo {
+    uint32_t maxFramesInFlight;
+    glm::i32vec2 viewportDimensions;
+};
+/// the outputs of a layer's render task
+struct LayerPassOutputs {
+    TransientTextureHandle color;
+    TransientTextureHandle depth;
+};
+
 class ImGuiLayer;
 class DepthDebugLayer;
 

--- a/Cory/include/Cory/Application/DepthDebugLayer.hpp
+++ b/Cory/include/Cory/Application/DepthDebugLayer.hpp
@@ -18,6 +18,8 @@ class DepthDebugLayer : public ApplicationLayer {
     bool onEvent(Event event) override;
     void onUpdate() override;
 
+    [[nodiscard]] bool hasRenderTask() const override { return renderEnabled.get(); }
+
     RenderTaskDeclaration<LayerPassOutputs> renderTask(Cory::RenderTaskBuilder builder,
                                                        LayerPassOutputs previousLayer) override;
 

--- a/Cory/include/Cory/Application/ImGuiLayer.hpp
+++ b/Cory/include/Cory/Application/ImGuiLayer.hpp
@@ -8,6 +8,8 @@
 
 #include <Magnum/Vk/Vk.h>
 
+#include <Cory/Application/ApplicationLayer.hpp>
+
 #include <cstdint>
 #include <memory>
 
@@ -19,18 +21,22 @@ class Context;
 class Window;
 class FrameContext;
 
-class ImGuiLayer {
+class ImGuiLayer : public ApplicationLayer {
   public:
-    ImGuiLayer();
+    ImGuiLayer(Window& window);
     ~ImGuiLayer();
 
-    void init(Window &window, Context &ctx);
-    void deinit(Context &ctx);
-
+    void onAttach(Context &ctx, LayerAttachInfo info) override;
+    void onDetach(Context &ctx) override;
+    bool onEvent(Event event) override;
+    void onUpdate() override;
+    bool hasRenderTask() const override { return true; }
+    RenderTaskDeclaration<LayerPassOutputs> renderTask(Cory::RenderTaskBuilder builder,
+                                                       LayerPassOutputs previousLayer) override;
+  private:
     void newFrame(Context &ctx);
     void recordFrameCommands(Context &ctx, uint32_t frameIdx, Magnum::Vk::CommandBuffer &cmdBuffer);
 
-  private:
     struct Private;
     std::unique_ptr<Private> data_;
     void setupCustomColors();

--- a/Cory/include/Cory/Application/LayerStack.hpp
+++ b/Cory/include/Cory/Application/LayerStack.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <Cory/Application/Common.hpp>
+#include <Cory/Application/Event.hpp>
+#include <Cory/Renderer/Common.hpp>
+
+namespace Cory {
+
+/**
+ * @brief collects a stack of ApplicationLayers
+ *
+ * The layer stack defines the order in which layers are rendered and the order in which they
+ * receive events.
+ *  - Events are passed "downwards" in the layer stack:
+ *    Layers earlier in the stack are rendered first and receive events *last*.
+ *  - Updates happens bottom-up: Layers earlier in the stack are updated first.
+ *  - Layers are rendered bottom-up: Layers earlier in the stack are rendered first.
+ */
+class LayerStack {
+  public:
+    explicit LayerStack(Context &ctx);
+    ~LayerStack();
+
+    /// emplace a layer
+    template <typename T, typename... Args>
+        requires std::is_base_of_v<ApplicationLayer, T>
+    T &addLayer(LayerAttachInfo attachInfo, Args... args)
+    {
+        auto &layer = layers_.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
+        layer->onAttach(ctx_, attachInfo);
+        return *static_cast<T *>(layers_.back().get());
+    }
+
+    std::unique_ptr<ApplicationLayer> removeLayer(const std::string &name);
+
+    /// update all layers
+    void update();
+
+    /// pass an event top-down to the first layer that accepts it
+    bool onEvent(Event event);
+
+    /// queue render tasks for all layers, bottom-up
+    [[maybe_unused]] LayerPassOutputs declareRenderTasks(Framegraph &framegraph,
+                                                         LayerPassOutputs previousLayer);
+
+    /// list layers
+    const std::vector<std::unique_ptr<ApplicationLayer>> &layers() const { return layers_; }
+
+  private:
+    Context &ctx_;
+    std::vector<std::unique_ptr<ApplicationLayer>> layers_;
+};
+} // namespace Cory

--- a/Cory/include/Cory/Renderer/Common.hpp
+++ b/Cory/include/Cory/Renderer/Common.hpp
@@ -9,8 +9,8 @@
 #include <Magnum/Vk/Vk.h> // forward declaration header
 #include <Magnum/Vk/Vulkan.h>
 
-#include <Cory/Renderer/Synchronization.hpp>
 #include <Cory/Renderer/Semaphore.hpp> // Semaphore.hpp is a tiny header so it's ok
+#include <Cory/Renderer/Synchronization.hpp>
 #include <Cory/Renderer/flextVkExt.h> // extensions
 
 #include <cstdint>
@@ -18,6 +18,7 @@
 namespace Cory {
 // forward declared classes/structs
 class Context;
+struct ContextCreationInfo;
 class CpuBuffer;
 class RenderManager;
 class Shader;

--- a/Cory/src/Application/Application.cpp
+++ b/Cory/src/Application/Application.cpp
@@ -1,4 +1,35 @@
 #include <Cory/Application/Application.hpp>
 
+#include <Cory/Application/LayerStack.hpp>
+#include <Cory/Renderer/Context.hpp>
+
 namespace Cory {
+
+struct ApplicationPrivate {
+    Context ctx;
+    LayerStack layers;
+
+    ApplicationPrivate(ContextCreationInfo info)
+        : ctx{info}
+        , layers{ctx}
+    {
+    }
+};
+
+Application::Application() {}
+
+void Application::init(const ContextCreationInfo &info)
+{
+    data_ = std::make_unique<ApplicationPrivate>(info);
+}
+
+// <editor-fold desc="Accessors">
+Context &Application::ctx() { return data_->ctx; }
+const Context &Application::ctx() const { return data_->ctx; }
+LayerStack &Application::layers() { return data_->layers; }
+const LayerStack &Application::layers() const { return data_->layers; }
+// </editor-fold>
+
+Application::~Application() = default;
+
 } // namespace Cory

--- a/Cory/src/Application/ImGuiLayer.cpp
+++ b/Cory/src/Application/ImGuiLayer.cpp
@@ -3,6 +3,9 @@
 #include <Cory/Application/Window.hpp>
 #include <Cory/Base/FmtUtils.hpp>
 #include <Cory/Base/Log.hpp>
+#include <Cory/Base/Utils.hpp>
+#include <Cory/Framegraph/CommandList.hpp>
+#include <Cory/Framegraph/RenderTaskBuilder.hpp>
 #include <Cory/Renderer/Context.hpp>
 #include <Cory/Renderer/SingleShotCommandBuffer.hpp>
 #include <Cory/Renderer/Swapchain.hpp>
@@ -132,10 +135,12 @@ void check_vk_result(VkResult err)
     if (err < 0) { abort(); }
 }
 
-ImGuiLayer::ImGuiLayer()
-    : data_{std::make_unique<Private>()}
+ImGuiLayer::ImGuiLayer(Window &window)
+    : ApplicationLayer("ImGui")
+    , data_{std::make_unique<Private>()}
 {
     data_->clearValue = {0.0f, 0.0f, 0.0f, 0.0f};
+    data_->window = &window;
 }
 
 ImGuiLayer::~ImGuiLayer()
@@ -145,9 +150,10 @@ ImGuiLayer::~ImGuiLayer()
     }
 }
 
-void ImGuiLayer::init(Window &window, Context &ctx)
+void ImGuiLayer::onAttach(Context &ctx, LayerAttachInfo attachInfo)
 {
-    data_->window = &window;
+    auto &window = *data_->window;
+
     data_->descriptorPool = createImguiDescriptorPool(ctx);
     data_->renderPass = createImguiRenderpass(ctx, window.colorFormat(), window.sampleCount());
 
@@ -225,7 +231,7 @@ void ImGuiLayer::init(Window &window, Context &ctx)
     // setupCustomColors();
 }
 
-void ImGuiLayer::deinit(Context &ctx)
+void ImGuiLayer::onDetach(Context &ctx)
 {
     // free all buffers before destroying the imgui context
     data_.reset();
@@ -235,11 +241,48 @@ void ImGuiLayer::deinit(Context &ctx)
     ImGui::DestroyContext();
 }
 
-void ImGuiLayer::newFrame(Context &ctx)
+bool ImGuiLayer::onEvent(Event event)
+{
+    return std::visit(lambda_visitor{
+                          [](auto event) { return false; },
+//                          [this](const SwapchainResizedEvent &event) {
+//                              //
+//                              return false;
+//                          },
+//                          [this](const ScrollEvent &event) {
+//                              //
+//                              return false;
+//                          },
+//                          [this](const MouseMovedEvent &event) {
+//                              //
+//                              return false;
+//                          },
+                      },
+                      event);
+}
+
+void ImGuiLayer::onUpdate()
 {
     ImGui_ImplVulkan_NewFrame();
     ImGui_ImplGlfw_NewFrame();
     ImGui::NewFrame();
+}
+
+RenderTaskDeclaration<LayerPassOutputs> ImGuiLayer::renderTask(Cory::RenderTaskBuilder builder,
+                                                               LayerPassOutputs previousLayer)
+{
+    auto [writtenColorHandle, colorInfo] =
+        builder.readWrite(previousLayer.color, Cory::Sync::AccessType::ColorAttachmentWrite);
+
+    co_yield LayerPassOutputs{.color = writtenColorHandle, .depth = previousLayer.depth};
+    Cory::RenderInput renderApi = co_await builder.finishDeclaration();
+
+    Context &ctx = *renderApi.ctx;
+    FrameContext &frameCtx = *renderApi.frameCtx;
+
+    // note - currently, we're letting imgui handle the final resolve and transition to
+    // present_layout
+    recordFrameCommands(ctx, frameCtx.index, renderApi.cmd->handle());
 }
 
 void ImGuiLayer::recordFrameCommands(Context &ctx,
@@ -269,6 +312,7 @@ void ImGuiLayer::recordFrameCommands(Context &ctx,
     ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmdBuffer);
     cmdBuffer.endRenderPass();
 }
+
 void ImGuiLayer::setupCustomColors()
 {
     ImVec4 *colors = ImGui::GetStyle().Colors;

--- a/Cory/src/Application/LayerStack.cpp
+++ b/Cory/src/Application/LayerStack.cpp
@@ -1,0 +1,62 @@
+#include <Cory/Application/LayerStack.hpp>
+
+#include <Cory/Application/ApplicationLayer.hpp>
+#include <Cory/Framegraph/Framegraph.hpp>
+
+#include <range/v3/view/reverse.hpp>
+
+namespace Cory {
+
+LayerStack::LayerStack(Context &ctx)
+    : ctx_{ctx}
+{
+}
+
+LayerStack::~LayerStack()
+{
+    for (auto &layer : layers_) {
+        layer->onDetach(ctx_);
+    }
+}
+
+std::unique_ptr<ApplicationLayer> LayerStack::removeLayer(const std::string &name)
+{
+    auto it = std::find_if(layers_.begin(), layers_.end(), [&](const auto &layer) {
+        return layer->name.get() == name;
+    });
+    if (it == layers_.end()) { return nullptr; }
+    auto layer = std::move(*it);
+    layers_.erase(it);
+    layer->onDetach(ctx_);
+    return layer;
+}
+
+void LayerStack::update()
+{
+    for (auto &layer : layers_) {
+        layer->onUpdate();
+    }
+}
+
+bool LayerStack::onEvent(Event event)
+{
+    for (auto &layer : ranges::views::reverse(layers_)) {
+        if (layer->onEvent(event)) { return true; }
+    }
+    return false;
+}
+
+LayerPassOutputs LayerStack::declareRenderTasks(Framegraph &framegraph,
+                                                LayerPassOutputs previousLayer)
+{
+    for (auto &layer : layers_) {
+        if (layer->hasRenderTask()) {
+            previousLayer =
+                layer->renderTask(framegraph.declareTask(layer->name.get()), previousLayer)
+                    .output();
+        }
+    }
+    return previousLayer;
+}
+
+} // namespace Cory

--- a/Cory/src/Application/LayerStack.cpp
+++ b/Cory/src/Application/LayerStack.cpp
@@ -52,7 +52,8 @@ LayerPassOutputs LayerStack::declareRenderTasks(Framegraph &framegraph,
     for (auto &layer : layers_) {
         if (layer->hasRenderTask()) {
             previousLayer =
-                layer->renderTask(framegraph.declareTask(layer->name.get()), previousLayer)
+                layer
+                    ->renderTask(framegraph.declareTask("TASK_" + layer->name.get()), previousLayer)
                     .output();
         }
     }

--- a/Cory/test/CMakeLists.txt
+++ b/Cory/test/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(${TARGET_NAME}_TestLib OBJECT
         DescriptorSetManager_Test.cpp
         VulkanUtils_Test.cpp
         Time_Test.cpp
-        )
+        LayerStack_test.cpp)
 
 target_link_libraries(${TARGET_NAME}_TestLib PUBLIC Catch2::Catch2)
 target_link_libraries(${TARGET_NAME}_TestLib PRIVATE Cory::project_options)

--- a/Cory/test/LayerStack_test.cpp
+++ b/Cory/test/LayerStack_test.cpp
@@ -1,0 +1,177 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <Cory/Application/ApplicationLayer.hpp>
+#include <Cory/Application/LayerStack.hpp>
+#include <Cory/Framegraph/Framegraph.hpp>
+#include <Cory/Framegraph/RenderTaskBuilder.hpp>
+
+#include "TestUtils.hpp"
+
+class MockLayer : public Cory::ApplicationLayer {
+  public:
+    MockLayer(std::string name, int &counter)
+        : ApplicationLayer(name)
+        , counter(counter)
+    {
+    }
+    ~MockLayer() { REQUIRE(detached_); }
+
+    int &counter;
+    bool attached_{false};
+    bool detached_{false};
+    int updatedIndex_{-1};
+    bool hasRenderTask_{false};
+    bool acceptsEvents_{false};
+    std::vector<Cory::Event> receivedEvents_;
+
+    bool hasRenderTask() const override { return hasRenderTask_; }
+    void onAttach(Cory::Context &ctx, Cory::LayerAttachInfo info) override { attached_ = true; }
+    void onDetach(Cory::Context &ctx) override { detached_ = true; }
+    void onUpdate() override { updatedIndex_ = counter++; }
+
+    bool onEvent(Cory::Event event) override
+    {
+        updatedIndex_ = counter++;
+        if (acceptsEvents_) {
+            receivedEvents_.push_back(event);
+            return true;
+        }
+        return false;
+    }
+
+    Cory::RenderTaskDeclaration<Cory::LayerPassOutputs>
+    renderTask(Cory::RenderTaskBuilder builder, Cory::LayerPassOutputs previousLayer) override
+    {
+        updatedIndex_ = counter++;
+        co_yield Cory::LayerPassOutputs{};
+    }
+};
+
+TEST_CASE("LayerStack", "[LayerStack]")
+{
+    Cory::testing::VulkanTester tester;
+
+    GIVEN("A layer stack")
+    {
+        Cory::LayerStack stack(tester.ctx());
+        WHEN("Attaching layers")
+        {
+            int counter{0};
+            Cory::LayerAttachInfo info{};
+            MockLayer &layer1 = stack.addLayer<MockLayer>(info, "Layer 1", std::ref(counter));
+            MockLayer &layer2 = stack.addLayer<MockLayer>(info, "Layer 2", std::ref(counter));
+            MockLayer &layer3 = stack.addLayer<MockLayer>(info, "Layer 3", std::ref(counter));
+
+            REQUIRE(stack.layers().size() == 3);
+
+            THEN("The layers are initialized correctly")
+            {
+                REQUIRE(layer1.name.get() == "Layer 1");
+                REQUIRE(layer2.name.get() == "Layer 2");
+                REQUIRE(layer3.name.get() == "Layer 3");
+            }
+
+            THEN("The layers are attached correctly")
+            {
+                REQUIRE(layer1.attached_);
+                REQUIRE(layer2.attached_);
+                REQUIRE(layer3.attached_);
+            }
+
+            AND_WHEN("Removing a layer")
+            {
+                auto layer_ptr = stack.removeLayer("Layer 2");
+                THEN("The layer is not in the stack anymore")
+                {
+                    REQUIRE(stack.layers().size() == 2);
+                    REQUIRE(stack.layers()[0].get() == &layer1);
+                    REQUIRE(stack.layers()[1].get() == &layer3);
+                }
+                THEN("The layer is detached")
+                {
+                    REQUIRE(static_cast<MockLayer *>(layer_ptr.get())->detached_);
+                }
+            }
+        }
+    }
+    GIVEN("A layer stack with layers")
+    {
+        Cory::LayerStack stack(tester.ctx());
+
+        int counter{0};
+        Cory::LayerAttachInfo info{};
+        MockLayer &layer1 = stack.addLayer<MockLayer>(info, "Layer 1", std::ref(counter));
+        MockLayer &layer2 = stack.addLayer<MockLayer>(info, "Layer 2", std::ref(counter));
+        MockLayer &layer3 = stack.addLayer<MockLayer>(info, "Layer 3", std::ref(counter));
+
+        WHEN("Updating the stack")
+        {
+            stack.update();
+            THEN("The layers are updated in the correct order")
+            {
+                REQUIRE(layer1.updatedIndex_ == 0);
+                REQUIRE(layer2.updatedIndex_ == 1);
+                REQUIRE(layer3.updatedIndex_ == 2);
+            }
+        }
+        WHEN("Passing events through a stack that does not accept any events")
+        {
+            bool processed = stack.onEvent(Cory::Event{});
+            THEN("The event is passed to the layers that accept it")
+            {
+                REQUIRE(layer1.receivedEvents_.size() == 0);
+                REQUIRE(layer2.receivedEvents_.size() == 0);
+                REQUIRE(layer3.receivedEvents_.size() == 0);
+
+                REQUIRE(layer1.updatedIndex_ == 2);
+                REQUIRE(layer2.updatedIndex_ == 1);
+                REQUIRE(layer3.updatedIndex_ == 0);
+
+                REQUIRE(processed == false);
+            }
+        }
+        WHEN("Passing events down a stack where at least one layer accepts it")
+        {
+            layer1.acceptsEvents_ = true;
+            layer2.acceptsEvents_ = true;
+            bool processed = stack.onEvent(Cory::Event{});
+            THEN("The event is passed to the first layer from the top that accepts it")
+            {
+                REQUIRE(layer1.receivedEvents_.size() == 0);
+                REQUIRE(layer2.receivedEvents_.size() == 1);
+                REQUIRE(layer3.receivedEvents_.size() == 0);
+
+                REQUIRE(processed == true);
+            }
+        }
+        WHEN("Enqueueing the render tasks")
+        {
+            Cory::Framegraph framegraph(tester.ctx());
+
+            SECTION("No layers have a render task")
+            {
+                stack.declareRenderTasks(framegraph, Cory::LayerPassOutputs{});
+                THEN("No layer is called")
+                {
+                    REQUIRE(layer1.updatedIndex_ == -1);
+                    REQUIRE(layer2.updatedIndex_ == -1);
+                    REQUIRE(layer3.updatedIndex_ == -1);
+                }
+            }
+
+            SECTION("All layers have a render task")
+            {
+                layer1.hasRenderTask_ = true;
+                layer2.hasRenderTask_ = true;
+                layer3.hasRenderTask_ = true;
+                stack.declareRenderTasks(framegraph, Cory::LayerPassOutputs{});
+                THEN("The layers are updated in the correct order")
+                {
+                    REQUIRE(layer1.updatedIndex_ == 0);
+                    REQUIRE(layer2.updatedIndex_ == 1);
+                    REQUIRE(layer3.updatedIndex_ == 2);
+                }
+            }
+        }
+    }
+}

--- a/Cory/test/LayerStack_test.cpp
+++ b/Cory/test/LayerStack_test.cpp
@@ -80,7 +80,7 @@ TEST_CASE("LayerStack", "[LayerStack]")
 
             AND_WHEN("Removing a layer")
             {
-                auto layer_ptr = stack.removeLayer("Layer 2");
+                auto layer_ptr = stack.detachLayer("Layer 2");
                 THEN("The layer is not in the stack anymore")
                 {
                     REQUIRE(stack.layers().size() == 2);

--- a/CubeDemo/src/CubeDemo.cpp
+++ b/CubeDemo/src/CubeDemo.cpp
@@ -462,24 +462,22 @@ void CubeDemoApplication::drawImguiControls()
 
 void CubeDemoApplication::setupCameraCallbacks()
 {
-    window_->onSwapchainResized.connect(
-        [this](Cory::SwapchainResizedEvent event) { camera_.setWindowSize(event.size); });
+    window_->onSwapchainResized.connect([this](Cory::SwapchainResizedEvent event) {
+        layers().onEvent(event);
+        camera_.setWindowSize(event.size);
+    });
 
     window_->onMouseMoved.connect([this](Cory::MouseMovedEvent event) {
-        if (ImGui::GetIO().WantCaptureMouse) { return; }
-
         if (layers().onEvent(event)) { return; }
         if (event.button != Cory::MouseButton::None) {
             camera_.mouseMove(glm::ivec2(event.position), event.button, event.modifiers);
         }
     });
     window_->onMouseButton.connect([this](Cory::MouseButtonEvent event) {
-        if (ImGui::GetIO().WantCaptureMouse) { return; }
         if (layers().onEvent(event)) { return; }
         camera_.setMousePosition(event.position);
     });
     window_->onMouseScrolled.connect([this](Cory::ScrollEvent event) {
-        if (ImGui::GetIO().WantCaptureMouse) { return; }
         if (layers().onEvent(event)) { return; }
         camera_.wheel(static_cast<int32_t>(event.scrollDelta.y));
     });

--- a/CubeDemo/src/CubeDemo.hpp
+++ b/CubeDemo/src/CubeDemo.hpp
@@ -23,7 +23,7 @@ struct CubeUBO {
     glm::vec3 lightPosition;
 };
 
-class CubeDemoApplication : public Cory::Application, Cory::NoCopy, Cory::NoMove {
+class CubeDemoApplication : public Cory::Application {
   public:
     CubeDemoApplication(int argc, char **argv);
     ~CubeDemoApplication();
@@ -61,7 +61,6 @@ class CubeDemoApplication : public Cory::Application, Cory::NoCopy, Cory::NoMove
   private:
     bool disableValidation_{false};
     uint64_t framesToRender_{0}; // the frames to render - 0 is infinite
-    std::unique_ptr<Cory::Context> ctx_;
     std::unique_ptr<Cory::Window> window_;
 
     Cory::SamplerHandle defaultSampler_;

--- a/CubeDemo/src/CubeDemo.hpp
+++ b/CubeDemo/src/CubeDemo.hpp
@@ -67,7 +67,6 @@ class CubeDemoApplication : public Cory::Application {
     Cory::ShaderHandle vertexShader_;
     Cory::ShaderHandle fragmentShader_;
     std::unique_ptr<Magnum::Vk::Mesh> mesh_;
-    std::unique_ptr<Cory::DepthDebugLayer> depthDebugLayer_;
     std::unique_ptr<Cory::ImGuiLayer> imguiLayer_;
 
     std::unique_ptr<Cory::UniformBufferObject<CubeUBO>> globalUbo_;

--- a/CubeDemo/src/CubeDemo.hpp
+++ b/CubeDemo/src/CubeDemo.hpp
@@ -46,11 +46,6 @@ class CubeDemoApplication : public Cory::Application {
                    Cory::TransientTextureHandle colorTarget,
                    Cory::TransientTextureHandle depthTarget);
 
-    Cory::RenderTaskDeclaration<PassOutputs>
-    imguiRenderTask(Cory::RenderTaskBuilder builder,
-                    Cory::TransientTextureHandle colorTarget,
-                    Cory::FrameContext ctx);
-
     static double now();
     [[nodiscard]] double getElapsedTimeSeconds() const;
 
@@ -67,7 +62,6 @@ class CubeDemoApplication : public Cory::Application {
     Cory::ShaderHandle vertexShader_;
     Cory::ShaderHandle fragmentShader_;
     std::unique_ptr<Magnum::Vk::Mesh> mesh_;
-    std::unique_ptr<Cory::ImGuiLayer> imguiLayer_;
 
     std::unique_ptr<Cory::UniformBufferObject<CubeUBO>> globalUbo_;
     std::vector<Magnum::Vk::DescriptorSet> descriptorSets_;

--- a/CubeDemo/src/main.cpp
+++ b/CubeDemo/src/main.cpp
@@ -1,3 +1,5 @@
+#include <Cory/Cory.hpp>
+
 #include "CubeDemo.hpp"
 
 #include <cstdlib>
@@ -8,6 +10,7 @@
 int main(int argc, char** argv)
 {
     try {
+        Cory::Init();
         CubeDemoApplication app{argc, argv};
 
         app.run();


### PR DESCRIPTION
Extends the infrastructure around the `ApplicationLayer` / `LayerStack`.
Each `Cory::Application` now has its own automatic layer stack that new layers can be added to.

Closes #28