### PR TITLE
Add HeadlessFrameSource and headless mode for examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif ()
 # Make sure release builds still have debug info
 if (MSVC)
     add_compile_options("$<$<CONFIG:Release>:/Zi>")
+    add_compile_options("/Zc:preprocessor")
     add_link_options("$<$<CONFIG:Release>:/DEBUG>")
 else ()
     add_compile_options("$<$<CONFIG:Release>:-g>")

--- a/cbt.ps1
+++ b/cbt.ps1
@@ -1,0 +1,93 @@
+<#
+Cory build tool launcher
+- Uses a build root under the repository `build` folder (same folder as this script's directory).
+- `setup` creates a virtualenv in <build>\.venv, installs tools/cbt, and runs `conan install` for Debug and Release configs.
+- `start` or `-h` activates the venv (if present) and shows `cbt` help.
+- Default: activates venv and forwards all args to `python -m cbt`.
+
+Usage:
+  .\cbt.ps1 setup
+  .\cbt.ps1 start
+  .\cbt.ps1 <other cbt args...>
+
+Run PowerShell with: powershell -NoProfile -ExecutionPolicy Bypass -File .\cbt.ps1 setup
+#>
+
+# Set-StrictMode -Version Latest
+# $ErrorActionPreference = 'Stop'
+
+# Determine script and repo locations
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$buildRoot = Join-Path $scriptDir 'build'
+$venvDir = Join-Path $buildRoot '.venv'
+
+# Helper to run commands and throw on failure
+function Run-Command {
+    param(
+        [Parameter(Mandatory=$true)][string]$FilePath,
+        [Parameter(Mandatory=$false)][string[]]$Arguments
+    )
+    if ($null -eq $Arguments) { $Arguments = @() }
+    Write-Output "Running: $FilePath $($Arguments -join ' ')"
+    & $FilePath @Arguments
+    $code = $LASTEXITCODE
+    if ($code -ne 0) { throw ("Command '{0} {1}' failed with exit code {2}" -f $FilePath, ($Arguments -join ' '), $code) }
+}
+
+# Grab first argument as subcommand
+$sub = if ($args.Count -ge 1) { $args[0] } else { $null }
+
+if ($sub -eq 'setup') {
+    if (-not (Test-Path $buildRoot)) {
+        New-Item -ItemType Directory -Path $buildRoot | Out-Null
+    }
+
+    if (-not (Test-Path $venvDir)) {
+        Write-Output "Creating virtual environment at: $venvDir"
+        Run-Command -FilePath 'python' -Arguments @('-m','venv', $venvDir)
+    } else {
+        Write-Output "Virtual environment already exists at: $venvDir"
+    }
+
+    # Install the in-repo tools/cbt package into the venv using pip (via python -m pip)
+    $toolsPath = Join-Path $scriptDir 'tools\cbt'
+    if (-not (Test-Path $toolsPath)) {
+        Write-Warning "tools/cbt not found at: $toolsPath - skipping editable install"
+    } else {
+        Run-Command -FilePath 'python' -Arguments @('-m','pip','install','-e',$toolsPath)
+    }
+
+    Write-Output "cbt: virtual environment set up at: $venvDir"
+    Write-Output "Activate it in PowerShell with: . '$venvDir\Scripts\Activate.ps1' and then run: ./cbt --help"
+    exit 0
+}
+
+if ($sub -eq 'start' -or $sub -eq '-h' -or $sub -eq '--help') {
+    $activate = Join-Path $venvDir 'Scripts\Activate.ps1'
+    if (Test-Path $activate) {
+        Write-Output "Activating virtual environment: $venvDir"
+        . $activate
+    } else {
+        Write-Warning "Virtual environment not found at $venvDir. Run '.\cbt.ps1 setup' first."
+    }
+
+    Write-Output "Cory build tool (cbt) working correctly. Showing help..."
+    Run-Command -FilePath 'python' -Arguments @('-m','cbt','--help')
+    exit 0
+}
+
+# Default: activate venv if present and forward args to python -m cbt
+$activate = Join-Path $venvDir 'Scripts\Activate.ps1'
+if (Test-Path $activate) {
+    Write-Output "Activating virtual environment: $venvDir"
+    . $activate
+} else {
+    Write-Warning "Virtual environment not found at $venvDir. Run '.\cbt.ps1 setup' first."
+}
+
+# MSVC activation removed from PowerShell launcher; Python-side `cbt` will activate the developer environment when needed.
+
+# Forward all args to cbt
+& python -m cbt $args
+
+exit 0

--- a/examples/01-HelloTriangle/CMakeLists.txt
+++ b/examples/01-HelloTriangle/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(${TARGET_NAME}
 
 if (CORY_BUILD_TESTS)
     enable_testing()
-add_test(NAME Smoketests.HelloTriangle COMMAND ${TARGET_NAME} --frames=100)
+add_test(NAME Smoketests.HelloTriangle COMMAND ${TARGET_NAME} --frames=100 --headless)
 endif ()
 
 # Install in the desired folder

--- a/examples/01-HelloTriangle/src/HelloTriangleApplication.cpp
+++ b/examples/01-HelloTriangle/src/HelloTriangleApplication.cpp
@@ -193,22 +193,15 @@ void HelloTriangleApplication::run()
         recordCommands(frameCtx);
     };
 
-    if (headless_) {
-        for (auto &frameCtx : headlessFrames_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
+    auto frames = headless_ ? headlessFrames_->frames() : window_->frames();
+
+    for (auto &frameCtx : frames) {
+        runFrame(frameCtx);
+        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+            break;
         }
     }
-    else {
-        for (auto &frameCtx : window_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
-        }
-    }
+    
     // wait until last frame is finished rendering
     ctx().device().waitUntilIdle();
 }

--- a/examples/01-HelloTriangle/src/HelloTriangleApplication.cpp
+++ b/examples/01-HelloTriangle/src/HelloTriangleApplication.cpp
@@ -12,6 +12,7 @@
 #include <Cory/Cory.hpp>
 #include <Cory/Renderer/Context.hpp>
 #include <Cory/Renderer/FrameContext.hpp>
+#include <Cory/Renderer/HeadlessFrameSource.hpp>
 #include <Cory/Renderer/MappedCoherentDeviceBuffer.hpp>
 
 #include <KDGpu/buffer_options.h>
@@ -90,6 +91,7 @@ HelloTriangleApplication::HelloTriangleApplication(int argc, char **argv)
     CLI::App app{"HelloTriangle"};
     app.add_option("-f,--frames", framesToRender_, "The number of frames to render");
     app.add_flag("--disable-validation", disableValidation_, "Disable validation layers");
+    app.add_flag("--headless", headless_, "Run without a window and render offscreen");
     app.parse(argc, argv);
 
     Cory::ResourceLocator::addSearchPath(TRIANGLE_RESOURCE_DIR);
@@ -109,28 +111,50 @@ HelloTriangleApplication::HelloTriangleApplication(int argc, char **argv)
     CO_APP_INFO("MSAA sample count: {}", msaaSamples);
 
     static constexpr auto WINDOW_SIZE = glm::i32vec2{1024, 1024};
-    window_ = std::make_unique<Cory::Window>(ctx(), WINDOW_SIZE, "HelloTriangle", msaaSamples);
+    if (headless_) {
+        ctx().setupHeadlessDevice();
+        headlessFrames_ = std::make_unique<Cory::HeadlessFrameSource>(
+            ctx(),
+            Cory::HeadlessFrameSourceCreateInfo{
+                .label = "HelloTriangle-Headless",
+                .size = Cory::glmu::u32vec2::from(WINDOW_SIZE),
+                .samples = static_cast<Gpu::SampleCountFlagBits>(msaaSamples),
+            });
+    }
+    else {
+        window_ = std::make_unique<Cory::Window>(ctx(), WINDOW_SIZE, "HelloTriangle", msaaSamples);
+    }
 
     createGeometry();
+    const Gpu::Format colorFormat =
+        headless_ ? headlessFrames_->colorFormat() : window_->colorFormat();
+    const Gpu::Format depthFormat =
+        headless_ ? headlessFrames_->depthFormat() : window_->depthFormat();
+    const Gpu::SampleCountFlagBits sampleCount =
+        headless_ ? headlessFrames_->sampleCount() : window_->samples();
     pipeline_ =
         std::make_unique<TrianglePipeline>(ctx(),
-                                           *window_,
+                                           colorFormat,
+                                           depthFormat,
+                                           sampleCount,
                                            *mesh_,
                                            std::filesystem::path{"simple_shader.vert.slang"},
                                            std::filesystem::path{"simple_shader.frag.slang"});
 
-    auto recreateSizedResources = [&](Cory::SwapchainResizedEvent e) {
-        createFramebuffers();
-        layers().processEvent(e);
-    };
-    window_->onSwapchainResized.connect(recreateSizedResources);
-    recreateSizedResources({window_->dimensions()});
+    if (!headless_) {
+        auto recreateSizedResources = [&](Cory::SwapchainResizedEvent e) {
+            createFramebuffers();
+            layers().processEvent(e);
+        };
+        window_->onSwapchainResized.connect(recreateSizedResources);
+        recreateSizedResources({window_->dimensions()});
 
-    Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
-                                          .viewportDimensions = window_->dimensions()};
-    // ImGui layer does not currently support non-dynamic rendering anymore..
-    // imguiLayer_ =
-    //    &layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
+        Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
+                                              .viewportDimensions = window_->dimensions()};
+        // ImGui layer does not currently support non-dynamic rendering anymore..
+        // imguiLayer_ =
+        //    &layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
+    }
 }
 
 HelloTriangleApplication::~HelloTriangleApplication()
@@ -146,10 +170,11 @@ void HelloTriangleApplication::run()
 
     auto time = getElapsedTimeSeconds();
 
-    for (auto &frameCtx : window_->frames()) {
-
+    auto runFrame = [&](Cory::FrameContext &frameCtx) {
         // Process KDGui events
-        processEvents(0);
+        if (!headless_) {
+            processEvents(0);
+        }
 
         // Update time
         auto previousFrameTime = std::exchange(time, getElapsedTimeSeconds());
@@ -166,10 +191,22 @@ void HelloTriangleApplication::run()
         // drawImguiControls();
 
         recordCommands(frameCtx);
+    };
 
-        // break if number of frames to render are reached
-        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-            break;
+    if (headless_) {
+        for (auto &frameCtx : headlessFrames_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
+        }
+    }
+    else {
+        for (auto &frameCtx : window_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
         }
     }
     // wait until last frame is finished rendering

--- a/examples/01-HelloTriangle/src/HelloTriangleApplication.hpp
+++ b/examples/01-HelloTriangle/src/HelloTriangleApplication.hpp
@@ -9,6 +9,7 @@ class TrianglePipeline;
 namespace Cory {
 class Window;
 class Context;
+class HeadlessFrameSource;
 } // namespace Cory
 
 struct Mesh;
@@ -34,11 +35,13 @@ class HelloTriangleApplication : public Cory::Application {
 
     uint64_t framesToRender_{0}; // the frames to render - 0 is infinite
     std::unique_ptr<Cory::Window> window_;
+    std::unique_ptr<Cory::HeadlessFrameSource> headlessFrames_;
     std::unique_ptr<TrianglePipeline> pipeline_;
     std::unique_ptr<Mesh> mesh_;
     Cory::ImGuiLayer *imguiLayer_{};
 
     double startupTime_;
     bool disableValidation_{false};
+    bool headless_{false};
     void drawImguiControls();
 };

--- a/examples/01-HelloTriangle/src/TrianglePipeline.cpp
+++ b/examples/01-HelloTriangle/src/TrianglePipeline.cpp
@@ -1,6 +1,5 @@
 #include "TrianglePipeline.hpp"
 
-#include <Cory/Application/Window.hpp>
 #include <Cory/Base/Log.hpp>
 #include <Cory/Base/ResourceLocator.hpp>
 #include <Cory/Renderer/Context.hpp>
@@ -19,14 +18,17 @@ struct TrianglePipeline::PrivateData {
 };
 
 TrianglePipeline::TrianglePipeline(Cory::Context &context,
-                                   const Cory::Window &window,
+                                   Gpu::Format colorFormat,
+                                   Gpu::Format depthFormat,
+                                   Gpu::SampleCountFlagBits sampleCount,
                                    const Mesh &mesh,
                                    std::filesystem::path vertFile,
                                    std::filesystem::path fragFile)
     : data_{std::make_unique<PrivateData>()}
 {
     data_->ctx = &context;
-    createGraphicsPipeline(window, mesh, std::move(vertFile), std::move(fragFile));
+    createGraphicsPipeline(
+        colorFormat, depthFormat, sampleCount, mesh, std::move(vertFile), std::move(fragFile));
 }
 
 TrianglePipeline::~TrianglePipeline() {}
@@ -34,7 +36,9 @@ KDGpu::RenderPass &TrianglePipeline::mainRenderPass() { return data_->mainRender
 KDGpu::GraphicsPipeline &TrianglePipeline::pipeline() { return data_->pipeline; }
 KDGpu::PipelineLayout &TrianglePipeline::layout() { return data_->layout; }
 
-void TrianglePipeline::createGraphicsPipeline(const Cory::Window &window,
+void TrianglePipeline::createGraphicsPipeline(Gpu::Format colorFormat,
+                                              Gpu::Format depthFormat,
+                                              Gpu::SampleCountFlagBits sampleCount,
                                               const Mesh &mesh,
                                               std::filesystem::path vertFile,
                                               std::filesystem::path fragFile)
@@ -105,10 +109,10 @@ void TrianglePipeline::createGraphicsPipeline(const Cory::Window &window,
                                    .offset = sizeof(glm::vec3),
                                }},
             },
-        .renderTargets = {{.format = window.colorFormat()}},
+        .renderTargets = {{.format = colorFormat}},
         .depthStencil =
             {
-                .format = window.depthFormat(),
+                .format = depthFormat,
                 .depthWritesEnabled = true,
                 .depthCompareOperation = KDGpu::CompareOperation::Less,
             },
@@ -117,7 +121,7 @@ void TrianglePipeline::createGraphicsPipeline(const Cory::Window &window,
         },
         .multisample =
             {
-                .samples = window.samples(),
+                .samples = sampleCount,
                 .alphaToCoverageEnabled = false,
             },
     };

--- a/examples/01-HelloTriangle/src/TrianglePipeline.hpp
+++ b/examples/01-HelloTriangle/src/TrianglePipeline.hpp
@@ -23,7 +23,9 @@ struct Mesh {
 class TrianglePipeline : Cory::NoCopy {
   public:
     TrianglePipeline(Cory::Context &context,
-                     const Cory::Window &window,
+                     Gpu::Format colorFormat,
+                     Gpu::Format depthFormat,
+                     Gpu::SampleCountFlagBits sampleCount,
                      const Mesh &mesh,
                      std::filesystem::path vertFile,
                      std::filesystem::path fragFile);
@@ -35,7 +37,9 @@ class TrianglePipeline : Cory::NoCopy {
     KDGpu::PipelineLayout &layout();
 
   private:
-    void createGraphicsPipeline(const Cory::Window &window,
+    void createGraphicsPipeline(Gpu::Format colorFormat,
+                                Gpu::Format depthFormat,
+                                Gpu::SampleCountFlagBits sampleCount,
                                 const Mesh &mesh,
                                 std::filesystem::path vertFile,
                                 std::filesystem::path fragFile);

--- a/examples/02-CubeDemo/CMakeLists.txt
+++ b/examples/02-CubeDemo/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(${TARGET_NAME}
 
 if (CORY_BUILD_TESTS)
     enable_testing()
-add_test(NAME Smoketests.CubeDemo COMMAND ${TARGET_NAME} --frames=50)
+add_test(NAME Smoketests.CubeDemo COMMAND ${TARGET_NAME} --frames=50  --headless)
 endif ()
 
 # Install in the desired folder

--- a/examples/02-CubeDemo/src/CubeDemo.cpp
+++ b/examples/02-CubeDemo/src/CubeDemo.cpp
@@ -17,6 +17,7 @@
 #include <Cory/RenderTasks/StandardRenderTasks.hpp>
 #include <Cory/Renderer/Context.hpp>
 #include <Cory/Renderer/FrameContext.hpp>
+#include <Cory/Renderer/HeadlessFrameSource.hpp>
 #include <Cory/Renderer/Shader.hpp>
 #include <Cory/Renderer/ShaderManager.hpp>
 
@@ -120,6 +121,7 @@ CubeDemoApplication::CubeDemoApplication(int argc, const char **argv)
     CLI::App app{"CubeDemo"};
     app.add_option("-f,--frames", framesToRender_, "The number of frames to render");
     app.add_flag("--disable-validation", disableValidation_, "Disable validation layers");
+    app.add_flag("--headless", headless_, "Run without a window and render offscreen");
     app.parse(argc, argv);
 
     Cory::ResourceLocator::addSearchPath(CUBEDEMO_RESOURCE_DIR);
@@ -138,27 +140,41 @@ CubeDemoApplication::CubeDemoApplication(int argc, const char **argv)
     // CO_APP_INFO("MSAA sample count: {}", msaaSamples);
 
     static constexpr auto WINDOW_SIZE = glm::i32vec2{1024, 1024};
-    window_ = std::make_unique<Cory::Window>(ctx(), WINDOW_SIZE, "CubeDemo", 8);
+    if (headless_) {
+        ctx().setupHeadlessDevice();
+        headlessFrames_ = std::make_unique<Cory::HeadlessFrameSource>(
+            ctx(),
+            Cory::HeadlessFrameSourceCreateInfo{
+                .label = "CubeDemo-Headless",
+                .size = Cory::glmu::u32vec2::from(WINDOW_SIZE),
+                .samples = Gpu::SampleCountFlagBits::Samples8Bit,
+            });
+    }
+    else {
+        window_ = std::make_unique<Cory::Window>(ctx(), WINDOW_SIZE, "CubeDemo", 8);
+    }
 
     createGeometry();
     createShaders();
 
-    auto recreateSizedResources = [&](Cory::SwapchainResizedEvent e) {
-        // createFramebuffers();
-        layers().processEvent(e);
-    };
-    window_->onSwapchainResized.connect(recreateSizedResources);
-    recreateSizedResources({window_->dimensions()});
+    if (!headless_) {
+        auto recreateSizedResources = [&](Cory::SwapchainResizedEvent e) {
+            // createFramebuffers();
+            layers().processEvent(e);
+        };
+        window_->onSwapchainResized.connect(recreateSizedResources);
+        recreateSizedResources({window_->dimensions()});
 
-    Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
-                                          .viewportDimensions = window_->dimensions()};
-    layers().addLayer<Cory::DepthDebugLayer>(layerAttachInfo);
-    layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
+        Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
+                                              .viewportDimensions = window_->dimensions()};
+        layers().addLayer<Cory::DepthDebugLayer>(layerAttachInfo);
+        layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
 
-    camera_.setMode(Cory::CameraManipulator::Mode::Trackball);
-    camera_.setWindowSize(window_->dimensions());
-    camera_.setLookat({0.0f, 3.0f, 2.5f}, {0.0f, 4.0f, 2.0f}, {0.0f, 1.0f, 0.0f});
-    setupCameraCallbacks();
+        camera_.setMode(Cory::CameraManipulator::Mode::Trackball);
+        camera_.setWindowSize(window_->dimensions());
+        camera_.setLookat({0.0f, 3.0f, 2.5f}, {0.0f, 4.0f, 2.0f}, {0.0f, 1.0f, 0.0f});
+        setupCameraCallbacks();
+    }
 }
 
 void CubeDemoApplication::createShaders()
@@ -190,22 +206,28 @@ void CubeDemoApplication::run()
 
     auto time = getElapsedTimeSeconds();
 
-    for (auto &frameCtx : window_->frames()) {
+    auto runFrame = [&](Cory::FrameContext &frameCtx) {
         // Process KDGui events
-        processEvents(0);
-        glfwPollEvents();
+        if (!headless_) {
+            processEvents(0);
+            glfwPollEvents();
+        }
 
         // Update time
         auto previousFrameTime = std::exchange(time, getElapsedTimeSeconds());
         auto delta = time - previousFrameTime;
 
-        // Update layers
-        layers().update(Cory::LogicUpdateContext{
-            .simulationTime = time,
-            .deltaTime = delta,
-        });
+        if (!headless_) {
+            // Update layers
+            layers().update(Cory::LogicUpdateContext{
+                .simulationTime = time,
+                .deltaTime = delta,
+            });
+        }
 
-        drawImguiControls();
+        if (!headless_) {
+            drawImguiControls();
+        }
 
         Cory::Framegraph &fg = framegraphs[frameCtx.inFlightIndex];
         // retire old resources from the last time this framegraph was
@@ -222,9 +244,22 @@ void CubeDemoApplication::run()
             dumpNextFramegraph_ = false;
         }
 
-        // break if number of frames to render are reached
-        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-            break;
+    };
+
+    if (headless_) {
+        for (auto &frameCtx : headlessFrames_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
+        }
+    }
+    else {
+        for (auto &frameCtx : window_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
         }
     }
 

--- a/examples/02-CubeDemo/src/CubeDemo.cpp
+++ b/examples/02-CubeDemo/src/CubeDemo.cpp
@@ -246,20 +246,11 @@ void CubeDemoApplication::run()
 
     };
 
-    if (headless_) {
-        for (auto &frameCtx : headlessFrames_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
-        }
-    }
-    else {
-        for (auto &frameCtx : window_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
+    auto frames = headless_ ? headlessFrames_->frames() : window_->frames();
+    for (auto &frameCtx : frames) {
+        runFrame(frameCtx);
+        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+            break;
         }
     }
 

--- a/examples/02-CubeDemo/src/CubeDemo.hpp
+++ b/examples/02-CubeDemo/src/CubeDemo.hpp
@@ -17,6 +17,10 @@
 #include <type_traits>
 #include <vector>
 
+namespace Cory {
+class HeadlessFrameSource;
+}
+
 struct CubeUBO {
     glm::mat4 projection;
     glm::mat4 view;
@@ -74,8 +78,10 @@ class CubeDemoApplication : public Cory::Application {
 
   private:
     bool disableValidation_{false};
+    bool headless_{false};
     uint64_t framesToRender_{0}; // the frames to render - 0 is infinite
     std::unique_ptr<Cory::Window> window_;
+    std::unique_ptr<Cory::HeadlessFrameSource> headlessFrames_;
 
     Cory::ShaderHandle vertexShader_;
     Cory::ShaderHandle fragmentShader_;

--- a/examples/03-SceneGraph/CMakeLists.txt
+++ b/examples/03-SceneGraph/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${TARGET_NAME}
 if (CORY_BUILD_TESTS)
     enable_testing()
 add_test(NAME Smoketests.SceneGraph COMMAND 
-        ${TARGET_NAME} --frames=50 --headless)
+        ${TARGET_NAME} --frames=20 --headless)
 endif ()
 
 # Install in the desired folder

--- a/examples/03-SceneGraph/CMakeLists.txt
+++ b/examples/03-SceneGraph/CMakeLists.txt
@@ -36,7 +36,8 @@ target_link_libraries(${TARGET_NAME}
 
 if (CORY_BUILD_TESTS)
     enable_testing()
-add_test(NAME Smoketests.SceneGraph COMMAND ${TARGET_NAME} --frames=50)
+add_test(NAME Smoketests.SceneGraph COMMAND 
+        ${TARGET_NAME} --frames=50 --headless)
 endif ()
 
 # Install in the desired folder

--- a/examples/03-SceneGraph/src/SceneGraphDemo.cpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.cpp
@@ -11,10 +11,13 @@
 #include <Cory/Base/GlmUtils.hpp>
 #include <Cory/Base/Random.hpp>
 #include <Cory/Base/ResourceLocator.hpp>
+#include <Cory/Base/Time.hpp>
 #include <Cory/Framegraph/Framegraph.hpp>
 #include <Cory/ImGui/Inputs.hpp>
 #include <Cory/ImGui/Widgets.hpp>
+#include <Cory/RenderTasks/StandardRenderTasks.hpp>
 #include <Cory/Renderer/Context.hpp>
+#include <Cory/Renderer/FrameContext.hpp>
 #include <Cory/Renderer/HeadlessFrameSource.hpp>
 #include <Cory/Systems/TransformSystem.hpp>
 
@@ -26,9 +29,7 @@
 #include <gsl/gsl>
 #include <gsl/narrow>
 
-#include <Cory/Base/Time.hpp>
-#include <Cory/RenderTasks/StandardRenderTasks.hpp>
-#include <Cory/Renderer/FrameContext.hpp>
+
 #include <algorithm>
 
 SceneGraphDemoApplication::SceneGraphDemoApplication(std::span<const char *> args)

--- a/examples/03-SceneGraph/src/SceneGraphDemo.cpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.cpp
@@ -8,12 +8,14 @@
 #include <Cory/Application/ImGuiLayer.hpp>
 #include <Cory/Application/LayerStack.hpp>
 #include <Cory/Application/Window.hpp>
+#include <Cory/Base/GlmUtils.hpp>
 #include <Cory/Base/Random.hpp>
 #include <Cory/Base/ResourceLocator.hpp>
 #include <Cory/Framegraph/Framegraph.hpp>
 #include <Cory/ImGui/Inputs.hpp>
 #include <Cory/ImGui/Widgets.hpp>
 #include <Cory/Renderer/Context.hpp>
+#include <Cory/Renderer/HeadlessFrameSource.hpp>
 #include <Cory/Systems/TransformSystem.hpp>
 
 #include <CLI/App.hpp>
@@ -35,6 +37,7 @@ SceneGraphDemoApplication::SceneGraphDemoApplication(std::span<const char *> arg
     bool disableValidation{false};
     app.add_option("-f,--frames", framesToRender_, "The number of frames to render");
     app.add_flag("--disable-validation", disableValidation, "Disable validation layers");
+    app.add_flag("--headless", headless_, "Run without a window and render offscreen");
     app.allow_config_extras(true);
     app.parse(gsl::narrow<int>(args.size()), args.data());
 
@@ -49,16 +52,32 @@ SceneGraphDemoApplication::SceneGraphDemoApplication(std::span<const char *> arg
     // Use Cory API for MSAA sample count
     const int msaaSamples = 4; // Or use window_->samples() after window creation if needed
     static constexpr auto WINDOW_SIZE = glm::i32vec2{1024, 1024};
-    window_ = std::make_unique<Cory::Window>(ctx(), WINDOW_SIZE, "SceneGraphDemo", msaaSamples);
+    if (headless_) {
+        ctx().setupHeadlessDevice();
+        headlessFrames_ = std::make_unique<Cory::HeadlessFrameSource>(
+            ctx(),
+            Cory::HeadlessFrameSourceCreateInfo{
+                .label = "SceneGraphDemo-Headless",
+                .size = Cory::glmu::u32vec2::from(WINDOW_SIZE),
+                .samples = static_cast<Gpu::SampleCountFlagBits>(msaaSamples),
+            });
+    }
+    else {
+        window_ = std::make_unique<Cory::Window>(ctx(), WINDOW_SIZE, "SceneGraphDemo", msaaSamples);
+    }
 
     setupScene();
     setupSystems();
 
+    const auto viewportDimensions =
+        headless_ ? headlessFrames_->extent() : window_->dimensions();
     Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
-                                          .viewportDimensions = window_->dimensions()};
+                                          .viewportDimensions = viewportDimensions};
     cameraLayer_ = &layers().addLayer<Cory::CameraLayer>(layerAttachInfo);
-    layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
-    layers().connectToWindow(*window_);
+    if (!headless_) {
+        layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
+        layers().connectToWindow(*window_);
+    }
 
     clock_.setTimeScale(0.01);
 }
@@ -181,20 +200,26 @@ void SceneGraphDemoApplication::run()
     });
 
     auto time = Cory::AppClock::now();
-    for (auto &frameCtx : window_->frames()) {
-        processEvents(0);
+    auto runFrame = [&](Cory::FrameContext &frameCtx) {
+        if (!headless_) {
+            processEvents(0);
+        }
 
         // Update time
         auto previousFrameTime = std::exchange(time, Cory::AppClock::now());
         auto delta = time - previousFrameTime;
 
-        // Update layers
-        layers().update(Cory::LogicUpdateContext{
-            .simulationTime = std::chrono::duration(time.time_since_epoch()).count(),
-            .deltaTime = delta.count(),
-        });
+        if (!headless_) {
+            // Update layers
+            layers().update(Cory::LogicUpdateContext{
+                .simulationTime = std::chrono::duration(time.time_since_epoch()).count(),
+                .deltaTime = delta.count(),
+            });
+        }
 
-        drawImguiControls();
+        if (!headless_) {
+            drawImguiControls();
+        }
         // tick the components
         auto tickInfo = clock_.tick();
         systems_.tick(sceneGraph_, tickInfo);
@@ -214,9 +239,22 @@ void SceneGraphDemoApplication::run()
             dumpNextFramegraph_ = false;
         }
 
-        // break if number of frames to render are reached
-        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-            break;
+    };
+
+    if (headless_) {
+        for (auto &frameCtx : headlessFrames_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
+        }
+    }
+    else {
+        for (auto &frameCtx : window_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
         }
     }
 

--- a/examples/03-SceneGraph/src/SceneGraphDemo.cpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.cpp
@@ -71,7 +71,7 @@ SceneGraphDemoApplication::SceneGraphDemoApplication(std::span<const char *> arg
     setupSystems();
 
     const auto viewportDimensions =
-        headless_ ? headlessFrames_->extent() : window_->dimensions();
+        headless_ ? glm::i32vec2(headlessFrames_->extent()) : window_->dimensions();
     Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
                                           .viewportDimensions = viewportDimensions};
     cameraLayer_ = &layers().addLayer<Cory::CameraLayer>(layerAttachInfo);

--- a/examples/03-SceneGraph/src/SceneGraphDemo.cpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.cpp
@@ -242,20 +242,11 @@ void SceneGraphDemoApplication::run()
 
     };
 
-    if (headless_) {
-        for (auto &frameCtx : headlessFrames_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
-        }
-    }
-    else {
-        for (auto &frameCtx : window_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
+    auto frames = headless_ ? headlessFrames_->frames() : window_->frames();
+    for (auto &frameCtx : frames) {
+        runFrame(frameCtx);
+        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+            break;
         }
     }
 

--- a/examples/03-SceneGraph/src/SceneGraphDemo.hpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.hpp
@@ -11,6 +11,10 @@
 #include <memory>
 #include <span>
 
+namespace Cory {
+class HeadlessFrameSource;
+}
+
 class SceneGraphDemoApplication : public Cory::Application {
   public:
     SceneGraphDemoApplication(std::span<const char *> args);
@@ -27,6 +31,8 @@ class SceneGraphDemoApplication : public Cory::Application {
   private:
     uint64_t framesToRender_{0}; // the frames to render - 0 is infinite
     std::unique_ptr<Cory::Window> window_;
+    std::unique_ptr<Cory::HeadlessFrameSource> headlessFrames_;
+    bool headless_{false};
 
     bool dumpNextFramegraph_{false};
 

--- a/examples/04-DynamicPipeline/CMakeLists.txt
+++ b/examples/04-DynamicPipeline/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(${TARGET_NAME}
 
 if (CORY_BUILD_TESTS)
     enable_testing()
-add_test(NAME Smoketests.DynamicPipeline COMMAND ${TARGET_NAME} --frames=100)
+add_test(NAME Smoketests.DynamicPipeline COMMAND ${TARGET_NAME} --frames=100 --headless)
 endif ()
 
 install(TARGETS ${TARGET_NAME}

--- a/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
+++ b/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
@@ -417,6 +417,9 @@ void DynamicPipelineApplication::recordCommands(Cory::FrameContext &frameCtx)
 void DynamicPipelineApplication::renderImGuiOverlay(Cory::FrameContext &frameCtx,
                                                     KDGpu::RenderPassCommandRecorder *recorder)
 {
+    if (!imguiLayer_) {
+        return;
+    }
     imguiLayer_->recordFrameCommands(frameCtx, recorder);
 }
 

--- a/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
+++ b/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
@@ -6,12 +6,14 @@
 #include <Cory/Application/Window.hpp>
 #include <Cory/Base/FileWatchManager.hpp>
 #include <Cory/Base/FmtUtils.hpp>
+#include <Cory/Base/GlmUtils.hpp>
 #include <Cory/Base/Profiling.hpp>
 #include <Cory/Base/ResourceLocator.hpp>
 #include <Cory/Cory.hpp>
 #include <Cory/ImGui/Inputs.hpp>
 #include <Cory/Renderer/Context.hpp>
 #include <Cory/Renderer/FrameContext.hpp>
+#include <Cory/Renderer/HeadlessFrameSource.hpp>
 #include <Cory/Renderer/Shader.hpp>
 #include <Cory/Renderer/ShaderManager.hpp>
 #include <Cory/Renderer/Swapchain.hpp>
@@ -73,6 +75,7 @@ DynamicPipelineApplication::DynamicPipelineApplication(int argc, char **argv)
     CLI::App app{"DynamicPipeline"};
     app.add_option("-f,--frames", framesToRender_, "Limit the number of rendered frames");
     app.add_flag("--disable-validation", disableValidation_, "Disable validation layers");
+    app.add_flag("--headless", headless_, "Run without a window and render offscreen");
     app.parse(argc, argv);
 
     Cory::ResourceLocator::addSearchPath(DYNAMIC_PIPELINE_RESOURCE_DIR);
@@ -83,24 +86,38 @@ DynamicPipelineApplication::DynamicPipelineApplication(int argc, char **argv)
     });
 
     static constexpr auto WINDOW_SIZE = glm::i32vec2{1280, 720};
-    window_ = std::make_unique<Cory::Window>(
-        ctx(), WINDOW_SIZE, "04 - Dynamic Pipeline", /*sample count*/ 1);
+    if (headless_) {
+        ctx().setupHeadlessDevice();
+        headlessFrames_ = std::make_unique<Cory::HeadlessFrameSource>(
+            ctx(),
+            Cory::HeadlessFrameSourceCreateInfo{
+                .label = "DynamicPipeline-Headless",
+                .size = Cory::glmu::u32vec2::from(WINDOW_SIZE),
+                .samples = Gpu::SampleCountFlagBits::Samples1Bit,
+            });
+    }
+    else {
+        window_ = std::make_unique<Cory::Window>(
+            ctx(), WINDOW_SIZE, "04 - Dynamic Pipeline", /*sample count*/ 1);
+    }
 
     resetAttachmentLayouts();
     shaderAutoReloadTask_ = loadShaders();
     createGeometry();
 
-    auto recreateSizedResources = [&](Cory::SwapchainResizedEvent e) {
-        resetAttachmentLayouts();
-        layers().processEvent(e);
-    };
-    window_->onSwapchainResized.connect(recreateSizedResources);
-    recreateSizedResources({window_->dimensions()});
+    if (!headless_) {
+        auto recreateSizedResources = [&](Cory::SwapchainResizedEvent e) {
+            resetAttachmentLayouts();
+            layers().processEvent(e);
+        };
+        window_->onSwapchainResized.connect(recreateSizedResources);
+        recreateSizedResources({window_->dimensions()});
 
-    Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
-                                          .viewportDimensions = window_->dimensions()};
-    imguiLayer_ =
-        &layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
+        Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
+                                              .viewportDimensions = window_->dimensions()};
+        imguiLayer_ =
+            &layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
+    }
 }
 
 DynamicPipelineApplication::~DynamicPipelineApplication()
@@ -116,8 +133,10 @@ void DynamicPipelineApplication::run()
     auto finalSync = gsl::finally([this]() { ctx().device().waitUntilIdle(); });
     double currentTime = getElapsedTimeSeconds();
 
-    for (auto &frameCtx : window_->frames()) {
-        processEvents();
+    auto runFrame = [&](Cory::FrameContext &frameCtx) {
+        if (!headless_) {
+            processEvents();
+        }
         // Process any file changes - triggers e.g. shader reloads
         ctx().fileWatchManager().processPendingEvents();
 
@@ -126,12 +145,16 @@ void DynamicPipelineApplication::run()
         double previousTime = std::exchange(currentTime, getElapsedTimeSeconds());
         const double delta = currentTime - previousTime;
 
-        layers().update(Cory::LogicUpdateContext{
-            .simulationTime = currentTime,
-            .deltaTime = delta,
-        });
+        if (!headless_) {
+            layers().update(Cory::LogicUpdateContext{
+                .simulationTime = currentTime,
+                .deltaTime = delta,
+            });
+        }
 
-        drawUi(frameCtx);
+        if (!headless_) {
+            drawUi(frameCtx);
+        }
 
         if (requestCompile_) {
             compileFragmentShaderSource(fragmentShaderEditorSource_, frameCtx.frameNumber);
@@ -139,9 +162,22 @@ void DynamicPipelineApplication::run()
         }
 
         recordCommands(frameCtx);
+    };
 
-        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-            break;
+    if (headless_) {
+        for (auto &frameCtx : headlessFrames_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
+        }
+    }
+    else {
+        for (auto &frameCtx : window_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
         }
     }
 }
@@ -238,7 +274,8 @@ void DynamicPipelineApplication::recordCommands(Cory::FrameContext &frameCtx)
             .view = *frameCtx.swapchainImageView,
             .clearValue = {r, g, b, 1.0f},
             .initialLayout = Gpu::TextureLayout::ColorAttachmentOptimal,
-            .finalLayout = Gpu::TextureLayout::PresentSrc,
+            .finalLayout = headless_ ? Gpu::TextureLayout::ColorAttachmentOptimal
+                                     : Gpu::TextureLayout::PresentSrc,
         }},
         .depthStencilAttachment =
             {
@@ -528,13 +565,14 @@ bool DynamicPipelineApplication::compileFragmentShaderSource(std::string_view so
 
 void DynamicPipelineApplication::resetAttachmentLayouts()
 {
-    if (!window_) {
+    if (!window_ && !headlessFrames_) {
         swapchainLayouts_.clear();
         depthLayouts_.clear();
         return;
     }
 
-    const size_t imageCount = window_->swapchain().size();
+    const size_t imageCount =
+        window_ ? window_->swapchain().size() : headlessFrames_->size();
     swapchainLayouts_.assign(imageCount, Gpu::TextureLayout::Undefined);
     depthLayouts_.assign(imageCount, Gpu::TextureLayout::Undefined);
 }
@@ -577,6 +615,9 @@ void DynamicPipelineApplication::transitionColorAttachmentForRender(Cory::FrameC
 
 void DynamicPipelineApplication::transitionColorAttachmentForPresent(Cory::FrameContext &frameCtx)
 {
+    if (headless_) {
+        return;
+    }
     if (swapchainLayouts_.empty()) {
         return;
     }

--- a/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
+++ b/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
@@ -164,20 +164,11 @@ void DynamicPipelineApplication::run()
         recordCommands(frameCtx);
     };
 
-    if (headless_) {
-        for (auto &frameCtx : headlessFrames_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
-        }
-    }
-    else {
-        for (auto &frameCtx : window_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
+    auto frames = headless_ ? headlessFrames_->frames() : window_->frames();
+    for (auto &frameCtx : frames) {
+        runFrame(frameCtx);
+        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+            break;
         }
     }
 }

--- a/examples/04-DynamicPipeline/src/DynamicPipelineApplication.hpp
+++ b/examples/04-DynamicPipeline/src/DynamicPipelineApplication.hpp
@@ -13,6 +13,7 @@
 
 namespace Cory {
 class ImGuiLayer;
+class HeadlessFrameSource;
 class Window;
 struct FrameContext;
 } // namespace Cory
@@ -68,9 +69,11 @@ class DynamicPipelineApplication : public Cory::Application {
 
     uint64_t framesToRender_{0};
     bool disableValidation_{false};
+    bool headless_{false};
     double startupTime_{0.0};
 
     std::unique_ptr<Cory::Window> window_;
+    std::unique_ptr<Cory::HeadlessFrameSource> headlessFrames_;
     Cory::ImGuiLayer *imguiLayer_{nullptr};
     Cory::Mesh mesh_;
 

--- a/examples/05-ParticleCompute/CMakeLists.txt
+++ b/examples/05-ParticleCompute/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(${TARGET_NAME}
 
 if (CORY_BUILD_TESTS)
     enable_testing()
-add_test(NAME Smoketests.Particle COMMAND ${TARGET_NAME} --frames=100)
+add_test(NAME Smoketests.Particle COMMAND ${TARGET_NAME} --frames=30  --headless)
 endif ()
 
 # Install in the desired folder

--- a/examples/05-ParticleCompute/CMakeLists.txt
+++ b/examples/05-ParticleCompute/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(${TARGET_NAME}
 
 if (CORY_BUILD_TESTS)
     enable_testing()
-add_test(NAME Smoketests.Particle COMMAND ${TARGET_NAME} --frames=30  --headless)
+add_test(NAME Smoketests.Particle COMMAND ${TARGET_NAME} --frames=20  --headless)
 endif ()
 
 # Install in the desired folder

--- a/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
+++ b/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
@@ -209,20 +209,11 @@ void ParticleComputeDemoApplication::run()
 
     };
 
-    if (headless_) {
-        for (auto &frameCtx : headlessFrames_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
-        }
-    }
-    else {
-        for (auto &frameCtx : window_->frames()) {
-            runFrame(frameCtx);
-            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-                break;
-            }
+    auto frames = headless_ ? headlessFrames_->frames() : window_->frames();
+    for (auto &frameCtx : frames) {
+        runFrame(frameCtx);
+        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+            break;
         }
     }
 

--- a/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
+++ b/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
@@ -7,6 +7,7 @@
 #include <Cory/Application/ImGuiLayer.hpp>
 #include <Cory/Application/LayerStack.hpp>
 #include <Cory/Application/Window.hpp>
+#include <Cory/Base/GlmUtils.hpp>
 #include <Cory/Base/Random.hpp>
 #include <Cory/Base/ResourceLocator.hpp>
 #include <Cory/Base/Time.hpp>
@@ -17,6 +18,7 @@
 #include <Cory/RenderTasks/StandardRenderTasks.hpp>
 #include <Cory/Renderer/Context.hpp>
 #include <Cory/Renderer/FrameContext.hpp>
+#include <Cory/Renderer/HeadlessFrameSource.hpp>
 #include <Cory/Systems/TransformSystem.hpp>
 
 #include <CLI/App.hpp>
@@ -36,6 +38,7 @@ ParticleComputeDemoApplication::ParticleComputeDemoApplication(std::span<const c
     bool disableValidation{false};
     app.add_option("-f,--frames", framesToRender_, "The number of frames to render");
     app.add_flag("--disable-validation", disableValidation, "Disable validation layers");
+    app.add_flag("--headless", headless_, "Run without a window and render offscreen");
     app.allow_config_extras(true);
     app.parse(gsl::narrow<int>(args.size()), args.data());
 
@@ -50,17 +53,33 @@ ParticleComputeDemoApplication::ParticleComputeDemoApplication(std::span<const c
     // Use Cory API for MSAA sample count
     const int msaaSamples = 2; // Or use window_->samples() after window creation if needed
     static constexpr auto WINDOW_SIZE = glm::i32vec2{1024, 1024};
-    window_ =
-        std::make_unique<Cory::Window>(ctx(), WINDOW_SIZE, "Particle Compute Demo", msaaSamples);
+    if (headless_) {
+        ctx().setupHeadlessDevice();
+        headlessFrames_ = std::make_unique<Cory::HeadlessFrameSource>(
+            ctx(),
+            Cory::HeadlessFrameSourceCreateInfo{
+                .label = "ParticleCompute-Headless",
+                .size = Cory::glmu::u32vec2::from(WINDOW_SIZE),
+                .samples = static_cast<Gpu::SampleCountFlagBits>(msaaSamples),
+            });
+    }
+    else {
+        window_ = std::make_unique<Cory::Window>(
+            ctx(), WINDOW_SIZE, "Particle Compute Demo", msaaSamples);
+    }
 
     setupScene();
     setupSystems();
 
+    const auto viewportDimensions =
+        headless_ ? headlessFrames_->extent() : window_->dimensions();
     Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
-                                          .viewportDimensions = window_->dimensions()};
+                                          .viewportDimensions = viewportDimensions};
     cameraLayer_ = &layers().addLayer<Cory::CameraLayer>(layerAttachInfo);
-    layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
-    layers().connectToWindow(*window_);
+    if (!headless_) {
+        layers().emplacePriorityLayer<Cory::ImGuiLayer>(layerAttachInfo, std::ref(*window_));
+        layers().connectToWindow(*window_);
+    }
 }
 
 void ParticleComputeDemoApplication::setupScene()
@@ -148,21 +167,27 @@ void ParticleComputeDemoApplication::run()
     });
 
     auto time = Cory::AppClock::now();
-    for (auto &frameCtx : window_->frames()) {
-        processEvents(0);
-        glfwPollEvents();
+    auto runFrame = [&](Cory::FrameContext &frameCtx) {
+        if (!headless_) {
+            processEvents(0);
+            glfwPollEvents();
+        }
 
         // Update time
         auto previousFrameTime = std::exchange(time, Cory::AppClock::now());
         auto delta = time - previousFrameTime;
 
-        // Update layers
-        layers().update(Cory::LogicUpdateContext{
-            .simulationTime = std::chrono::duration(time.time_since_epoch()).count(),
-            .deltaTime = delta.count(),
-        });
+        if (!headless_) {
+            // Update layers
+            layers().update(Cory::LogicUpdateContext{
+                .simulationTime = std::chrono::duration(time.time_since_epoch()).count(),
+                .deltaTime = delta.count(),
+            });
+        }
 
-        drawImguiControls();
+        if (!headless_) {
+            drawImguiControls();
+        }
         // tick the components
         auto tickInfo = clock_.tick();
         systems_.tick(sceneGraph_, tickInfo);
@@ -182,9 +207,22 @@ void ParticleComputeDemoApplication::run()
             dumpNextFramegraph_ = false;
         }
 
-        // break if number of frames to render are reached
-        if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
-            break;
+    };
+
+    if (headless_) {
+        for (auto &frameCtx : headlessFrames_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
+        }
+    }
+    else {
+        for (auto &frameCtx : window_->frames()) {
+            runFrame(frameCtx);
+            if (framesToRender_ > 0 && frameCtx.frameNumber >= framesToRender_) {
+                break;
+            }
         }
     }
 

--- a/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
+++ b/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
@@ -72,7 +72,7 @@ ParticleComputeDemoApplication::ParticleComputeDemoApplication(std::span<const c
     setupSystems();
 
     const auto viewportDimensions =
-        headless_ ? headlessFrames_->extent() : window_->dimensions();
+        headless_ ? glm::i32vec2(headlessFrames_->extent()) : window_->dimensions();
     Cory::LayerAttachInfo layerAttachInfo{.maxFramesInFlight = Cory::MAX_FRAMES_IN_FLIGHT,
                                           .viewportDimensions = viewportDimensions};
     cameraLayer_ = &layers().addLayer<Cory::CameraLayer>(layerAttachInfo);

--- a/examples/05-ParticleCompute/src/ParticleComputeDemo.hpp
+++ b/examples/05-ParticleCompute/src/ParticleComputeDemo.hpp
@@ -11,6 +11,10 @@
 #include <memory>
 #include <span>
 
+namespace Cory {
+class HeadlessFrameSource;
+}
+
 class ParticleComputeDemoApplication : public Cory::Application {
   public:
     explicit ParticleComputeDemoApplication(std::span<const char *> args);
@@ -27,6 +31,8 @@ class ParticleComputeDemoApplication : public Cory::Application {
   private:
     uint64_t framesToRender_{0}; // the frames to render - 0 is infinite
     std::unique_ptr<Cory::Window> window_;
+    std::unique_ptr<Cory::HeadlessFrameSource> headlessFrames_;
+    bool headless_{false};
 
     bool dumpNextFramegraph_{false};
 

--- a/src/Cory/CMakeLists.txt
+++ b/src/Cory/CMakeLists.txt
@@ -182,12 +182,6 @@ target_include_directories(${TARGET_NAME}
         ${IMGUI_BACKEND_DIR}
 )
 
-target_include_directories(${TARGET_NAME}
-        SYSTEM PUBLIC
-        $<TARGET_PROPERTY:KDGpu::KDGpu,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:KDGpu::KDGpuUtils,INTERFACE_INCLUDE_DIRECTORIES>
-)
-
 target_link_libraries(${TARGET_NAME}
         PUBLIC
         ${VULKAN_LIBRARIES}
@@ -201,9 +195,9 @@ target_link_libraries(${TARGET_NAME}
         range-v3::range-v3
         cppcoro::cppcoro
         spdlog::spdlog
-        KDGpu::KDGpu
+        SYSTEM PUBLIC KDGpu::KDGpu
+        SYSTEM PUBLIC KDGpu::KDGpuUtils
         glfw
-        KDGpu::KDGpuUtils
         KDUtils::KDGui
         Slang::slang
         efsw::efsw

--- a/src/Cory/CMakeLists.txt
+++ b/src/Cory/CMakeLists.txt
@@ -195,8 +195,8 @@ target_link_libraries(${TARGET_NAME}
         range-v3::range-v3
         cppcoro::cppcoro
         spdlog::spdlog
-        SYSTEM PUBLIC KDGpu::KDGpu
-        SYSTEM PUBLIC KDGpu::KDGpuUtils
+        KDGpu::KDGpu
+        KDGpu::KDGpuUtils
         glfw
         KDUtils::KDGui
         Slang::slang

--- a/src/Cory/CMakeLists.txt
+++ b/src/Cory/CMakeLists.txt
@@ -113,6 +113,8 @@ set(CORY_SOURCES
         Renderer/FrameGenerator.hpp
         Renderer/FrameContext.hpp
         Renderer/FrameResourceLifetimeHelper.hpp
+        Renderer/HeadlessFrameSource.cpp
+        Renderer/HeadlessFrameSource.hpp
         Renderer/Gpu.cpp
         Renderer/Gpu.hpp
         Renderer/GpuBumpAllocator.cpp

--- a/src/Cory/Renderer/HeadlessFrameSource.cpp
+++ b/src/Cory/Renderer/HeadlessFrameSource.cpp
@@ -1,0 +1,270 @@
+#include <Cory/Renderer/HeadlessFrameSource.hpp>
+
+#include <Cory/Base/FmtUtils.hpp>
+#include <Cory/Base/GlmUtils.hpp>
+#include <Cory/Base/Log.hpp>
+#include <Cory/Base/Profiling.hpp>
+#include <Cory/Renderer/Context.hpp>
+
+#include <KDGpu/texture.h>
+#include <KDGpu/texture_options.h>
+#include <KDGpuUtils/resource_deleter.h>
+
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/indices.hpp>
+#include <range/v3/view/transform.hpp>
+
+#include <array>
+#include <optional>
+
+namespace Cory {
+
+namespace {
+
+Gpu::Format selectDepthFormat(const Gpu::Adapter &adapter)
+{
+    constexpr std::array preferredDepthFormat = {
+        Gpu::Format::D24_UNORM_S8_UINT,
+        Gpu::Format::D16_UNORM_S8_UINT,
+        Gpu::Format::D32_SFLOAT_S8_UINT,
+        Gpu::Format::D16_UNORM,
+        Gpu::Format::D32_SFLOAT,
+    };
+    for (const auto &depthFormat : preferredDepthFormat) {
+        const auto formatProperties = adapter.formatProperties(depthFormat);
+        if (formatProperties.optimalTilingFeatures &
+            Gpu::FormatFeatureFlagBit::DepthStencilAttachmentBit) {
+            return depthFormat;
+        }
+    }
+    return Gpu::Format::D24_UNORM_S8_UINT;
+}
+
+} // namespace
+
+struct HeadlessFrameSourcePrivate {
+    Context *ctx{};
+    std::string label;
+    glm::u32vec2 extent{};
+    Gpu::SampleCountFlagBits sampleCount{Gpu::SampleCountFlagBits::Samples1Bit};
+    Gpu::Format colorFormat{Gpu::Format::B8G8R8A8_UNORM};
+    Gpu::Format depthFormat{Gpu::Format::D24_UNORM_S8_UINT};
+    size_t imageCount{MAX_FRAMES_IN_FLIGHT};
+
+    uint64_t frameNumber{0};
+
+    std::vector<Texture> swapchainImages;
+    std::vector<TextureView> swapchainViews;
+
+    std::vector<Texture> colorImages;
+    std::vector<TextureView> colorImageViews;
+    std::vector<Texture> depthImages;
+    std::vector<TextureView> depthImageViews;
+
+    std::array<Gpu::Fence, MAX_FRAMES_IN_FLIGHT> frameCompletedFences;
+    std::array<std::optional<Gpu::CommandBuffer>, MAX_FRAMES_IN_FLIGHT> commandBuffers;
+    std::unique_ptr<KDGpuUtils::ResourceDeleter> resourceDeleter;
+};
+
+HeadlessFrameSource::HeadlessFrameSource(Context &context, HeadlessFrameSourceCreateInfo createInfo)
+    : data_{std::make_unique<HeadlessFrameSourcePrivate>()}
+{
+    data_->ctx = &context;
+    data_->label = std::move(createInfo.label);
+    data_->extent = createInfo.size;
+    data_->sampleCount = createInfo.samples;
+    data_->colorFormat = createInfo.colorFormat;
+    data_->depthFormat = selectDepthFormat(*context.device().adapter());
+    data_->imageCount = std::max<size_t>(1, createInfo.imageCount);
+
+    auto &device = context.device();
+
+    for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i) {
+        data_->frameCompletedFences[i] = device.createFence({
+            .label = fmt::format("FENCE-{}-{}", data_->label, i),
+            .createSignalled = true,
+        });
+    }
+
+    const auto extent = data_->extent;
+    data_->swapchainImages =
+        ranges::views::indices(data_->imageCount) | ranges::views::transform([&](auto idx) {
+            return device.createTexture(Gpu::TextureOptions{
+                .label = fmt::format("TEX_HeadlessSwap[{}] {} (IMG)", idx, extent),
+                .type = Gpu::TextureType::TextureType2D,
+                .format = data_->colorFormat,
+                .extent = {extent.x, extent.y, 1},
+                .mipLevels = 1,
+                .samples = Gpu::SampleCountFlagBits::Samples1Bit,
+                .usage = Gpu::TextureUsageFlagBits::ColorAttachmentBit |
+                         Gpu::TextureUsageFlagBits::TransferDstBit |
+                         Gpu::TextureUsageFlagBits::TransferSrcBit |
+                         Gpu::TextureUsageFlagBits::SampledBit,
+                .memoryUsage = Gpu::MemoryUsage::GpuOnly,
+            });
+        }) |
+        ranges::to<std::vector>;
+
+    data_->swapchainViews = ranges::views::enumerate(data_->swapchainImages) |
+                            ranges::views::transform([extent](auto it) {
+                                auto [idx, image] = it;
+                                return image.createView(Gpu::TextureViewOptions{
+                                    .label =
+                                        fmt::format("TEX_HeadlessSwap[{}] {} (VIEW)", idx, extent),
+                                });
+                            }) |
+                            ranges::to<std::vector>;
+
+    data_->colorImages = ranges::views::indices(MAX_FRAMES_IN_FLIGHT) |
+                         ranges::views::transform([&](auto idx) {
+                             return device.createTexture(Gpu::TextureOptions{
+                                 .label = fmt::format("TEX_HeadlessColor[{}] {} (IMG)", idx, extent),
+                                 .type = Gpu::TextureType::TextureType2D,
+                                 .format = data_->colorFormat,
+                                 .extent = {extent.x, extent.y, 1},
+                                 .mipLevels = 1,
+                                 .samples = data_->sampleCount,
+                                 .usage = Gpu::TextureUsageFlagBits::ColorAttachmentBit |
+                                          Gpu::TextureUsageFlagBits::TransferSrcBit |
+                                          Gpu::TextureUsageFlagBits::SampledBit,
+                                 .memoryUsage = Gpu::MemoryUsage::GpuOnly,
+                             });
+                         }) |
+                         ranges::to<std::vector>;
+
+    data_->colorImageViews = ranges::views::enumerate(data_->colorImages) |
+                             ranges::views::transform([extent](auto it) {
+                                 auto [idx, image] = it;
+                                 return image.createView(Gpu::TextureViewOptions{
+                                     .label = fmt::format(
+                                         "TEX_HeadlessColor[{}] {} (VIEW)", idx, extent),
+                                 });
+                             }) |
+                             ranges::to<std::vector>;
+
+    data_->depthImages = ranges::views::indices(MAX_FRAMES_IN_FLIGHT) |
+                         ranges::views::transform([&](auto idx) {
+                             return device.createTexture(Gpu::TextureOptions{
+                                 .label = fmt::format("TEX_HeadlessDepth[{}] {} (IMG)", idx, extent),
+                                 .type = Gpu::TextureType::TextureType2D,
+                                 .format = data_->depthFormat,
+                                 .extent = {extent.x, extent.y, 1},
+                                 .mipLevels = 1,
+                                 .samples = data_->sampleCount,
+                                 .usage = Gpu::TextureUsageFlagBits::DepthStencilAttachmentBit |
+                                          Gpu::TextureUsageFlagBits::SampledBit,
+                                 .memoryUsage = Gpu::MemoryUsage::GpuOnly,
+                             });
+                         }) |
+                         ranges::to<std::vector>;
+
+    data_->depthImageViews = ranges::views::enumerate(data_->depthImages) |
+                             ranges::views::transform([extent](auto it) {
+                                 auto [idx, image] = it;
+                                 return image.createView(Gpu::TextureViewOptions{
+                                     .label = fmt::format(
+                                         "TEX_HeadlessDepth[{}] {} (VIEW)", idx, extent),
+                                 });
+                             }) |
+                             ranges::to<std::vector>;
+
+    data_->resourceDeleter =
+        std::make_unique<KDGpuUtils::ResourceDeleter>(&context.device(), MAX_FRAMES_IN_FLIGHT);
+}
+
+HeadlessFrameSource::~HeadlessFrameSource()
+{
+    CO_CORE_TRACE("Destroying Cory::HeadlessFrameSource.");
+}
+
+Gpu::Format HeadlessFrameSource::colorFormat() const noexcept
+{
+    return data_->colorFormat;
+}
+
+Gpu::Format HeadlessFrameSource::depthFormat() const noexcept
+{
+    return data_->depthFormat;
+}
+
+glm::u32vec2 HeadlessFrameSource::extent() const noexcept
+{
+    return data_->extent;
+}
+
+Gpu::SampleCountFlagBits HeadlessFrameSource::sampleCount() const noexcept
+{
+    return data_->sampleCount;
+}
+
+size_t HeadlessFrameSource::size() const noexcept
+{
+    return data_->swapchainImages.size();
+}
+
+cppcoro::generator<FrameContext> HeadlessFrameSource::frameGenerator()
+{
+    while (true) {
+        const auto nextFrameIndex =
+            static_cast<uint32_t>(data_->frameNumber % MAX_FRAMES_IN_FLIGHT);
+        const auto swapchainImageIndex =
+            static_cast<uint32_t>(data_->frameNumber % data_->swapchainImages.size());
+
+        auto recorder = data_->ctx->device().createCommandRecorder(Gpu::CommandRecorderOptions{
+            .label = fmt::format("CMD-Headless-Frame{:03}-[{}]", data_->frameNumber, nextFrameIndex),
+            .queue = data_->ctx->graphicsQueue().handle(),
+            .level = Gpu::CommandBufferLevel::Primary,
+        });
+
+        data_->frameCompletedFences[nextFrameIndex].wait();
+        data_->frameCompletedFences[nextFrameIndex].reset();
+
+        FrameContext frameCtx{
+            .inFlightIndex = nextFrameIndex,
+            .swapchainImageIndex = swapchainImageIndex,
+            .frameNumber = data_->frameNumber,
+            .extent = data_->extent,
+            .colorFormat = data_->colorFormat,
+            .depthFormat = data_->depthFormat,
+            .sampleCount = data_->sampleCount,
+            .swapchainImage = &data_->swapchainImages[swapchainImageIndex],
+            .swapchainImageView = &data_->swapchainViews[swapchainImageIndex],
+            .colorImage = &data_->colorImages[nextFrameIndex],
+            .colorImageView = &data_->colorImageViews[nextFrameIndex],
+            .depthImage = &data_->depthImages[nextFrameIndex],
+            .depthImageView = &data_->depthImageViews[nextFrameIndex],
+            .inFlight = &data_->frameCompletedFences[nextFrameIndex],
+            .acquired = nullptr,
+            .rendered = nullptr,
+            .commandBuffer = std::move(recorder),
+            .resourceDeleter = data_->resourceDeleter.get(),
+        };
+
+        ++data_->frameNumber;
+
+        co_yield std::move(frameCtx);
+    }
+}
+
+void HeadlessFrameSource::submit(FrameContext &frameCtx)
+{
+    const ScopeTimer s{"Headless/Submit"};
+
+    auto commandBuffer = frameCtx.commandBuffer.finish();
+
+    Gpu::SubmitOptions submitOptions{
+        .commandBuffers = {commandBuffer},
+        .signalFence = *frameCtx.inFlight,
+    };
+    data_->ctx->graphicsQueue().submit(submitOptions);
+
+    data_->commandBuffers[frameCtx.inFlightIndex] = std::move(commandBuffer);
+}
+
+FrameGenerator HeadlessFrameSource::frames()
+{
+    return FrameGenerator{frameGenerator(), [this](FrameContext &frameCtx) { submit(frameCtx); }};
+}
+
+} // namespace Cory

--- a/src/Cory/Renderer/HeadlessFrameSource.hpp
+++ b/src/Cory/Renderer/HeadlessFrameSource.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <Cory/Base/Common.hpp>
+#include <Cory/Renderer/Common.hpp>
+#include <Cory/Renderer/FrameGenerator.hpp>
+#include <Cory/Renderer/Gpu.hpp>
+
+#include <glm/vec2.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace Cory {
+
+struct HeadlessFrameSourceCreateInfo {
+    std::string label{"HeadlessFrameSource"};
+    glm::u32vec2 size{1024, 768};
+    Gpu::SampleCountFlagBits samples{Gpu::SampleCountFlagBits::Samples1Bit};
+    Gpu::Format colorFormat{Gpu::Format::B8G8R8A8_UNORM};
+    size_t imageCount{MAX_FRAMES_IN_FLIGHT};
+};
+
+class Context;
+
+class HeadlessFrameSource : NoCopy, NoMove {
+  public:
+    HeadlessFrameSource(Context &context, HeadlessFrameSourceCreateInfo createInfo);
+    ~HeadlessFrameSource();
+
+    [[nodiscard]] FrameGenerator frames();
+
+    [[nodiscard]] Gpu::Format colorFormat() const noexcept;
+    [[nodiscard]] Gpu::Format depthFormat() const noexcept;
+    [[nodiscard]] glm::u32vec2 extent() const noexcept;
+    [[nodiscard]] Gpu::SampleCountFlagBits sampleCount() const noexcept;
+    [[nodiscard]] size_t size() const noexcept;
+
+  private:
+    cppcoro::generator<FrameContext> frameGenerator();
+    void submit(FrameContext &frameCtx);
+
+    friend struct HeadlessFrameSourcePrivate;
+    std::unique_ptr<HeadlessFrameSourcePrivate> data_;
+};
+
+} // namespace Cory

--- a/tools/cbt/cbt/cli.py
+++ b/tools/cbt/cbt/cli.py
@@ -373,13 +373,42 @@ def _activate_vs_env_into(env: dict[str, str], inst_path: str, arch: str = "x64"
     raise MissingPrereq("Could not locate Visual Studio developer batch files (VsDevCmd.bat or vcvarsall.bat)")
 
 
-def _ensure_msvc_dev_env(env: dict[str, str], quiet: bool) -> dict[str, str]:
+def _ensure_msvc_dev_env(
+    env: dict[str, str],
+    quiet: bool,
+    cached_installation: str | None = None,
+    cached_env: dict[str, str] | None = None,
+) -> dict[str, str]:
     if not is_windows():
         return env
+    # If cl is already available in PATH, assume dev env active
     if _msvc_env_active(env):
         return env
-    # Try to locate an installation and activate its dev environment
-    inst = _find_vs_installation()
+    # If we have a cached environment dict from a prior configure, apply it instead
+    if cached_env:
+        new_env = dict(env)
+        # Merge PATH specially: prefer cached PATH entries first, then preserve existing
+        cached_path = cached_env.get("PATH") or cached_env.get("Path") or cached_env.get("path")
+        original_path = env.get("PATH") or env.get("Path") or env.get("path") or ""
+        if cached_path:
+            if original_path:
+                merged = f"{cached_path}{os.pathsep}{original_path}"
+            else:
+                merged = cached_path
+            new_env["PATH"] = merged
+        # Apply other cached variables (override)
+        for k, v in cached_env.items():
+            if k.upper() == "PATH":
+                continue
+            new_env[k] = v
+            try:
+                new_env[k.upper()] = v
+            except Exception:
+                pass
+        return new_env
+
+    # If a cached installation path was provided, use it; otherwise try to locate one.
+    inst = cached_installation or _find_vs_installation()
     if not inst:
         raise MissingPrereq("Visual Studio installation not found; please run 'x64 Native Tools Command Prompt' or install Visual Studio with C++ workload")
     if not quiet:
@@ -478,7 +507,39 @@ def configure(
     )
     env = _config_env(config)
     # Ensure MSVC dev environment is active on Windows when needed
-    env = _ensure_msvc_dev_env(env, ctx.quiet)
+    # Attempt to detect Visual Studio once and cache the installation path
+    # into the generated cbt config so future invocations can reuse it.
+    msvc_inst: str | None = None
+    if is_windows():
+        # Try a quick detection now; store into config so it gets written.
+        try:
+            msvc_inst = _find_vs_installation()
+        except Exception:
+            msvc_inst = None
+        if msvc_inst:
+            config.setdefault("msvc", {})["installation"] = msvc_inst
+    # If we detected an installation, activate the dev env now and capture the
+    # environment delta so future runs can reuse it without invoking the batch.
+    if is_windows() and msvc_inst:
+        try:
+            activated = _activate_vs_env_into(env, msvc_inst, "x64", ctx.quiet)
+            # Compute delta between original env and activated env
+            delta: dict[str, str] = {}
+            for k, v in activated.items():
+                orig = env.get(k)
+                if orig != v:
+                    delta[k] = v
+            # Persist installation path and env delta
+            msvc = config.setdefault("msvc", {})
+            msvc["installation"] = msvc_inst
+            msvc["env"] = delta
+            # Use the activated environment for the rest of configure
+            env = activated
+        except Exception:
+            # Fallback to attempting to ensure env (which will raise a helpful error)
+            env = _ensure_msvc_dev_env(env, ctx.quiet, cached_installation=msvc_inst)
+    else:
+        env = _ensure_msvc_dev_env(env, ctx.quiet, cached_installation=msvc_inst)
     # Debug: when not quiet, print a short PATH sample and whether cl is present in that PATH
     if not ctx.quiet and is_windows():
         sample_path = env.get("PATH", "")
@@ -569,7 +630,12 @@ def reconfigure(ctx: CliContext, profile: str | None, run_conan: bool, cmake_def
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, None)
     env = _config_env(config)
-    env = _ensure_msvc_dev_env(env, ctx.quiet)
+    env = _ensure_msvc_dev_env(
+        env,
+        ctx.quiet,
+        cached_installation=config.get("msvc", {}).get("installation"),
+        cached_env=config.get("msvc", {}).get("env"),
+    )
     tools = config["tools"]
     if run_conan:
         conan_mod.install(
@@ -631,7 +697,12 @@ def build(
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, build_root)
     env = _config_env(config)
-    env = _ensure_msvc_dev_env(env, ctx.quiet)
+    env = _ensure_msvc_dev_env(
+        env,
+        ctx.quiet,
+        cached_installation=config.get("msvc", {}).get("installation"),
+        cached_env=config.get("msvc", {}).get("env"),
+    )
     cmake_mod.build(
         config["tools"]["cmake"],
         build_dir,
@@ -641,6 +712,7 @@ def build(
         verbose,
         env,
         ctx.quiet,
+        native_tool=config.get("tools", {}).get("ninja"),
     )
 
 
@@ -664,6 +736,12 @@ def run_target(
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, build_root)
     env = _config_env(config)
+    env = _ensure_msvc_dev_env(
+        env,
+        ctx.quiet,
+        cached_installation=config.get("msvc", {}).get("installation"),
+        cached_env=config.get("msvc", {}).get("env"),
+    )
     if not no_build:
         # fail fast so we never run stale output if the build fails.
         cmake_mod.build(
@@ -675,6 +753,7 @@ def run_target(
             False,
             env,
             ctx.quiet,
+            native_tool=config.get("tools", {}).get("ninja"),
         )
     exe = build_dir / "bin" / (target + (".exe" if is_windows() else ""))
     if not exe.exists():
@@ -693,7 +772,12 @@ def list_targets(ctx: CliContext, profile: str | None, build_root: Path | None, 
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, build_root)
     env = _config_env(config)
-    env = _ensure_msvc_dev_env(env, ctx.quiet)
+    env = _ensure_msvc_dev_env(
+        env,
+        ctx.quiet,
+        cached_installation=config.get("msvc", {}).get("installation"),
+        cached_env=config.get("msvc", {}).get("env"),
+    )
     result = run(
         [config["tools"]["cmake"], "--build", str(build_dir), "--target", "help"],
         env=env,
@@ -752,11 +836,16 @@ def run_test(
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, build_root)
     env = _test_env(config)
-    env = _ensure_msvc_dev_env(env, ctx.quiet)
+    env = _ensure_msvc_dev_env(
+        env,
+        ctx.quiet,
+        cached_installation=config.get("msvc", {}).get("installation"),
+        cached_env=config.get("msvc", {}).get("env"),
+    )
     target_help = run(
         [config["tools"]["cmake"], "--build", str(build_dir), "--target", "help"],
         env=env,
-        quiet=ctx.quiet,
+        quiet=True,
     )
     available = set(_targets_from_help(target_help.stdout))
     for target in ["tests", "Cory_Tests"]:
@@ -770,6 +859,7 @@ def run_test(
                 False,
                 env,
                 ctx.quiet,
+                native_tool=config.get("tools", {}).get("ninja"),
             )
             break
     else:
@@ -782,6 +872,7 @@ def run_test(
             False,
             env,
             ctx.quiet,
+            native_tool=config.get("tools", {}).get("ninja"),
         )
     ctest_mod.run_tests(
         config["tools"]["ctest"],

--- a/tools/cbt/cbt/cli.py
+++ b/tools/cbt/cbt/cli.py
@@ -6,6 +6,8 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+import tempfile
+import subprocess
 
 import click
 
@@ -18,7 +20,7 @@ from . import format as format_mod
 from . import git as git_mod
 from . import run as run_mod
 from . import tidy as tidy_mod
-from .config import load_config, new_config, require_config, write_config
+from .config import new_config, require_config, write_config
 from .paths import (
     build_dir_for_profile,
     config_path,
@@ -41,6 +43,7 @@ from .util import (
     which,
     write_text,
 )
+from shutil import which as _shutil_which
 
 
 @dataclass
@@ -106,8 +109,7 @@ def _env_profile() -> str | None:
 
 
 def _resolve_profile(profile: str | None) -> str:
-    return profile or _env_profile() or "codex"
-
+    return profile or _env_profile() or "debug" if is_windows() else "codex"
 
 def _config_env(config: dict) -> dict[str, str]:
     env = dict(os.environ)
@@ -223,6 +225,168 @@ def _dir_size(path: Path) -> int:
     return total
 
 
+def _msvc_env_active(env: dict[str, str]) -> bool:
+    # Check whether 'cl' is available using the provided env's PATH
+    path = env.get("PATH")
+    return _shutil_which("cl", path=path) is not None
+
+
+def _find_vs_installation() -> str | None:
+    # Try vswhere in its typical location
+    program_files_x86 = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
+    if program_files_x86:
+        vswhere = Path(program_files_x86) / "Microsoft Visual Studio" / "Installer" / "vswhere.exe"
+        if vswhere.exists():
+            try:
+                res = run([str(vswhere), "-latest", "-products", "*", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", "-property", "installationPath"], quiet=True)
+                inst = res.stdout.strip()
+                if inst:
+                    return inst
+            except Exception:
+                pass
+
+    # Fallback: look for common installation folders and pick the newest
+    if program_files_x86:
+        base = Path(program_files_x86) / "Microsoft Visual Studio"
+        if base.exists():
+            # versions like 2017, 2019, 2022
+            candidates = list(base.glob("*") )
+            candidates = [p for p in candidates if (p / "Common7").exists()]
+            if candidates:
+                # return the one with highest name (best-effort)
+                candidates.sort()
+                return str(candidates[-1])
+    return None
+
+
+def _activate_vs_env_into(env: dict[str, str], inst_path: str, arch: str = "x64", quiet: bool = True) -> dict[str, str]:
+    # Try VsDevCmd.bat (newer) then vcvarsall.bat
+    # Honor override environment variable CORY_VSDEV_BAT to point to an exact batch file
+    override = os.environ.get("CORY_VSDEV_BAT")
+    inst = Path(inst_path)
+    # Candidate locations; prefer vcvarsall.bat then VsDevCmd.bat; allow override
+    candidates: list[Path] = []
+    if override:
+        cand = Path(override)
+        if cand.exists():
+            if not quiet:
+                sys.stdout.write(f"Using CORY_VSDEV_BAT override: {cand}\n")
+            candidates = [cand]
+        else:
+            if not quiet:
+                sys.stdout.write(f"CORY_VSDEV_BAT override set but path not found: {override}\n")
+            candidates = []
+    else:
+        # Standard vcvarsall path
+        std_vcvars = inst / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat"
+        std_vsdev = inst / "Common7" / "Tools" / "VsDevCmd.bat"
+        found_vcvars: list[Path] = []
+        found_vsdev: list[Path] = []
+        try:
+            for p in inst.rglob("vcvarsall.bat"):
+                found_vcvars.append(p)
+            for p in inst.rglob("VsDevCmd.bat"):
+                found_vsdev.append(p)
+        except Exception:
+            pass
+        # Prefer standard path if present
+        if std_vcvars.exists():
+            candidates.append(std_vcvars)
+        candidates.extend([p for p in found_vcvars if p != std_vcvars])
+        if std_vsdev.exists():
+            candidates.append(std_vsdev)
+        candidates.extend([p for p in found_vsdev if p != std_vsdev])
+
+    for bat in candidates:
+        if bat.exists():
+            if not quiet:
+                sys.stdout.write(f"Trying VS dev batch: {bat}\n")
+            # Create a temporary batch file that calls the dev batch and then emits the environment
+            # This avoids complex quoting issues when invoking cmd /c with embedded quotes.
+            tmp = None
+            try:
+                fd, tmp_path = tempfile.mkstemp(suffix=".bat", text=True)
+                tmp = Path(tmp_path)
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(f"@echo off\n")
+                    # Use CALL to run the target batch and then print environment
+                    # vcvarsall.bat expects 'x64' etc.; VsDevCmd.bat prefers '-arch=x64'
+                    bat_name = bat.name.lower()
+                    if bat_name == 'vcvarsall.bat':
+                        f.write(f"call \"{str(bat)}\" {arch}\n")
+                    else:
+                        f.write(f"call \"{str(bat)}\" -arch={arch}\n")
+                    f.write("set\n")
+                # Run the temp batch and capture stdout
+                try:
+                    comspec = os.environ.get("COMSPEC", "cmd")
+                    # Use subprocess.run to avoid the run() quoting/printing behavior and capture stdout
+                    stdout = ""
+                    proc = subprocess.run([comspec, "/c", str(tmp)], capture_output=True, text=True, check=True)
+                    stdout = proc.stdout
+                    if not quiet:
+                        sys.stdout.write(f"VsDev batch ran successfully, captured {len(stdout.splitlines())} env lines\n")
+                finally:
+                    try:
+                        tmp.unlink()
+                    except Exception:
+                        pass
+
+                new_env = dict(env)
+                captured: dict[str, str] = {}
+                for line in stdout.splitlines():
+                    if "=" in line:
+                        k, v = line.split("=", 1)
+                        captured[k] = v
+                        try:
+                            captured[k.upper()] = v
+                        except Exception:
+                            pass
+                # Merge PATH: prefer captured PATH first, but keep any original PATH entries so tools
+                # available in the invoking console (e.g. Git unix utils) remain accessible.
+                captured_path = captured.get('PATH') or captured.get('Path') or captured.get('path')
+                original_path = env.get('PATH') or env.get('Path') or env.get('path') or ''
+                if captured_path:
+                    if original_path:
+                        merged_path = f"{captured_path}{os.pathsep}{original_path}"
+                    else:
+                        merged_path = captured_path
+                    new_env['PATH'] = merged_path
+                # Import other captured variables into new_env (preserve original when absent)
+                for k, v in captured.items():
+                    if k.upper() == 'PATH':
+                        continue
+                    new_env[k] = v
+                    try:
+                        new_env[k.upper()] = v
+                    except Exception:
+                        pass
+                return new_env
+            except Exception:
+                # try next candidate
+                if tmp and tmp.exists():
+                    try:
+                        tmp.unlink()
+                    except Exception:
+                        pass
+                continue
+    raise MissingPrereq("Could not locate Visual Studio developer batch files (VsDevCmd.bat or vcvarsall.bat)")
+
+
+def _ensure_msvc_dev_env(env: dict[str, str], quiet: bool) -> dict[str, str]:
+    if not is_windows():
+        return env
+    if _msvc_env_active(env):
+        return env
+    # Try to locate an installation and activate its dev environment
+    inst = _find_vs_installation()
+    if not inst:
+        raise MissingPrereq("Visual Studio installation not found; please run 'x64 Native Tools Command Prompt' or install Visual Studio with C++ workload")
+    if not quiet:
+        sys.stdout.write(f"Found Visual Studio installation: {inst}\n")
+    return _activate_vs_env_into(env, inst, "x64", quiet)
+
+
 @click.group()
 @click.option("--quiet", is_flag=True, help="Suppress command echo.")
 @click.pass_context
@@ -313,6 +477,75 @@ def configure(
         vulkan_hints=vulkan_hints,
     )
     env = _config_env(config)
+    # Ensure MSVC dev environment is active on Windows when needed
+    env = _ensure_msvc_dev_env(env, ctx.quiet)
+    # Debug: when not quiet, print a short PATH sample and whether cl is present in that PATH
+    if not ctx.quiet and is_windows():
+        sample_path = env.get("PATH", "")
+        # print only the tail (last 3 entries) to avoid huge output
+        parts = sample_path.split(os.pathsep)
+        tail = os.pathsep.join(parts[-3:]) if len(parts) >= 3 else sample_path
+        sys.stdout.write(f"Detected PATH tail: {tail}\n")
+        detected = _find_executable_in_env_path(sample_path, "cl") or _shutil_which("cl", path=sample_path)
+        sys.stdout.write(f"cl found by detection: {detected}\n")
+    # If MSVC dev env activated, detect cl.exe in the captured PATH for diagnostics (do not set compilers)
+    if is_windows():
+        try:
+            cl_path = _shutil_which("cl", path=env.get("PATH", ""))
+        except Exception:
+            cl_path = None
+        if not cl_path:
+            # Fallback: look for cl.exe by scanning PATH entries directly
+            cl_path = _find_executable_in_env_path(env.get("PATH", ""), "cl")
+        if cl_path:
+            if not ctx.quiet:
+                sys.stdout.write(f"Using detected cl: {cl_path}\n")
+    # Strong diagnostic: print PATH and related VS env vars, and run 'where cl' via cmd with the captured env
+    if is_windows() and not ctx.quiet:
+        try:
+            path_full = env.get('PATH', '')
+            sys.stdout.write(f"Captured PATH length: {len(path_full)}\n")
+            parts = [p for p in path_full.split(os.pathsep) if p]
+            sys.stdout.write(f"Captured PATH entries (last 10): {parts[-10:]}\n")
+            for key in ('VSINSTALLDIR', 'VS150COMNTOOLS', 'VisualStudioVersion', 'VCToolsInstallDir'):
+                if key in env:
+                    sys.stdout.write(f"{key}={env.get(key)}\n")
+            comspec = os.environ.get('COMSPEC', 'cmd')
+            try:
+                proc = subprocess.run([comspec, '/c', 'where cl'], env=env, capture_output=True, text=True, check=False)
+                sys.stdout.write(f"where cl stdout:\n{proc.stdout}\n")
+                sys.stdout.write(f"where cl stderr:\n{proc.stderr}\n")
+            except Exception as ex:
+                sys.stdout.write(f"Failed to run where cl via subprocess: {ex}\n")
+            # Additional diagnostics: check git and sh visibility under the same env
+            try:
+                proc = subprocess.run([comspec, '/c', 'where git'], env=env, capture_output=True, text=True, check=False)
+                sys.stdout.write(f"where git stdout:\n{proc.stdout}\n")
+                sys.stdout.write(f"where git stderr:\n{proc.stderr}\n")
+            except Exception as ex:
+                sys.stdout.write(f"Failed to run where git via subprocess: {ex}\n")
+            try:
+                proc = subprocess.run([comspec, '/c', 'where sh'], env=env, capture_output=True, text=True, check=False)
+                sys.stdout.write(f"where sh stdout:\n{proc.stdout}\n")
+                sys.stdout.write(f"where sh stderr:\n{proc.stderr}\n")
+            except Exception as ex:
+                sys.stdout.write(f"Failed to run where sh via subprocess: {ex}\n")
+            # Try to run git --version and sh --version directly
+            try:
+                proc = subprocess.run(['git', '--version'], env=env, capture_output=True, text=True, check=False)
+                sys.stdout.write(f"git --version stdout:\n{proc.stdout}\n")
+                sys.stdout.write(f"git --version stderr:\n{proc.stderr}\n")
+            except Exception as ex:
+                sys.stdout.write(f"Failed to run 'git --version' via subprocess: {ex}\n")
+            try:
+                proc = subprocess.run(['sh', '--version'], env=env, capture_output=True, text=True, check=False)
+                sys.stdout.write(f"sh --version stdout:\n{proc.stdout}\n")
+                sys.stdout.write(f"sh --version stderr:\n{proc.stderr}\n")
+            except Exception as ex:
+                sys.stdout.write(f"Failed to run 'sh --version' via subprocess: {ex}\n")
+        except Exception as ex:
+            sys.stdout.write(f"Diagnostic failure: {ex}\n")
+
     cmake_mod.configure(
         tools["cmake"],
         build_dir,
@@ -336,6 +569,7 @@ def reconfigure(ctx: CliContext, profile: str | None, run_conan: bool, cmake_def
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, None)
     env = _config_env(config)
+    env = _ensure_msvc_dev_env(env, ctx.quiet)
     tools = config["tools"]
     if run_conan:
         conan_mod.install(
@@ -349,6 +583,24 @@ def reconfigure(ctx: CliContext, profile: str | None, run_conan: bool, cmake_def
         )
     defines = dict(config["cmake"]["defines"])
     defines.update(_parse_defines(cmake_define))
+    # If MSVC dev env activated, detect cl.exe in the captured PATH for diagnostics only
+    if is_windows():
+        try:
+            cl_path = _shutil_which("cl", path=env.get("PATH", ""))
+        except Exception:
+            cl_path = None
+        if not cl_path:
+            cl_path = _find_executable_in_env_path(env.get("PATH", ""), "cl")
+        if cl_path:
+            if not ctx.quiet:
+                sys.stdout.write(f"reconfigure: cl detected in captured PATH: {cl_path}\n")
+    # Diagnostic: confirm cl is visible when running subprocesses with the captured env
+    if is_windows() and not ctx.quiet:
+        try:
+            run(["where", "cl"], env=env, quiet=False)
+        except ToolError:
+            sys.stdout.write("Diagnostic: 'where cl' failed under captured env - cl not visible to subprocess.\n")
+
     cmake_mod.configure(
         tools["cmake"],
         build_dir,
@@ -379,6 +631,7 @@ def build(
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, build_root)
     env = _config_env(config)
+    env = _ensure_msvc_dev_env(env, ctx.quiet)
     cmake_mod.build(
         config["tools"]["cmake"],
         build_dir,
@@ -440,6 +693,7 @@ def list_targets(ctx: CliContext, profile: str | None, build_root: Path | None, 
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, build_root)
     env = _config_env(config)
+    env = _ensure_msvc_dev_env(env, ctx.quiet)
     result = run(
         [config["tools"]["cmake"], "--build", str(build_dir), "--target", "help"],
         env=env,
@@ -498,6 +752,7 @@ def run_test(
     profile = _resolve_profile(profile)
     config, build_dir = _load_or_fail(profile, build_root)
     env = _test_env(config)
+    env = _ensure_msvc_dev_env(env, ctx.quiet)
     target_help = run(
         [config["tools"]["cmake"], "--build", str(build_dir), "--target", "help"],
         env=env,
@@ -792,3 +1047,23 @@ def main() -> None:
     except click.UsageError as exc:
         sys.stderr.write(f"{exc}\n")
         raise SystemExit(1)
+
+def _find_executable_in_env_path(env_path: str, name: str) -> str | None:
+     """Search the PATH string from an env dict for an executable name. Returns full path or None."""
+     if not env_path:
+         return None
+     parts = env_path.split(os.pathsep)
+     # Try name and name.exe
+     candidates = [name, name + ".exe"]
+     for p in parts:
+         if not p:
+             continue
+         for cand in candidates:
+             try:
+                 path = Path(p) / cand
+                 if path.exists():
+                     return str(path)
+             except Exception:
+                 continue
+     return None
+

--- a/tools/cbt/cbt/cmake.py
+++ b/tools/cbt/cbt/cmake.py
@@ -40,7 +40,25 @@ def build(
     verbose: bool,
     env: dict[str, str] | None,
     quiet: bool,
+    native_tool: str | None = None,
 ) -> None:
+    # Prefer invoking the native build tool directly (e.g. ninja) when provided.
+    # Calling the native tool avoids CMake reconfigure step that `cmake --build`
+    # may trigger in some setups. Fall back to `cmake --build` when native_tool
+    # is not provided.
+    if native_tool:
+        # For ninja, use: ninja -C <build_dir> [target] [-jN]
+        cmd = [native_tool, "-C", str(build_dir)]
+        if target:
+            cmd.append(target)
+        if jobs:
+            cmd.append(f"-j{jobs}")
+        # ninja's verbose flag is -v
+        if verbose:
+            cmd.append("-v")
+        run(cmd, env=env, quiet=quiet)
+        return
+
     cmd = [cmake, "--build", str(build_dir), "--config", build_type]
     if target:
         cmd += ["--target", target]

--- a/tools/cbt/cbt/conan.py
+++ b/tools/cbt/cbt/conan.py
@@ -1,12 +1,76 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
-from .util import run
-
+from .util import run, write_text, read_text
 
 def ensure_profile_detected(conan: str, quiet: bool) -> None:
-    run([conan, "profile", "detect", "--force"], quiet=quiet)
+    try:
+        # If the default profile exists this will succeed; don't run detect.
+        run([conan, "profile", "show", "default"], quiet=True)
+        return
+    except Exception:
+        # No default profile: auto-detect one and then ensure cppstd=20
+        run([conan, "profile", "detect", "--force"], quiet=quiet)
+        # Conan 2 removed `profile update` - edit the profile file directly.
+        try:
+            # `conan profile path default` prints the path to the profile file.
+            res = run([conan, "profile", "path", "default"], quiet=True)
+            profile_path_str = res.stdout.strip()
+            if not profile_path_str:
+                return
+            profile_path = Path(profile_path_str)
+            if not profile_path.exists():
+                return
+
+            content = read_text(profile_path)
+            lines = content.splitlines(keepends=True)
+
+            # Find [settings] section
+            settings_idx = None
+            for i, line in enumerate(lines):
+                if line.strip().lower() == "[settings]":
+                    settings_idx = i
+                    break
+
+            cppstd_pattern = re.compile(r'^\s*(?:settings\.)?compiler\.cppstd\s*=\s*', re.IGNORECASE)
+
+            if settings_idx is not None:
+                # find end of [settings] (next section) and look for existing cppstd
+                end_idx = len(lines)
+                for j in range(settings_idx + 1, len(lines)):
+                    if lines[j].strip().startswith("["):
+                        end_idx = j
+                        break
+
+                found = False
+                for k in range(settings_idx + 1, end_idx):
+                    if cppstd_pattern.match(lines[k]):
+                        # replace the line with the desired setting
+                        lines[k] = re.sub(r'^(.*=).*', r"compiler.cppstd=20\n", lines[k])
+                        found = True
+                        break
+
+                if not found:
+                    # insert after the [settings] header
+                    insert_at = settings_idx + 1
+                    # keep consistent newline style
+                    nl = "\n" if not lines[settings_idx].endswith("\n") else ""
+                    lines.insert(insert_at, "compiler.cppstd=20\n")
+            else:
+                # No [settings] section - append one
+                if lines and not lines[-1].endswith("\n"):
+                    lines[-1] = lines[-1] + "\n"
+                lines.append("[settings]\n")
+                lines.append("compiler.cppstd=20\n")
+
+            new_content = "".join(lines)
+            if new_content != content:
+                write_text(profile_path, new_content)
+        except Exception:
+            # On any failure here we don't want to crash the whole setup; it's best-effort.
+            return
 
 
 def install(

--- a/tools/cbt/cbt/config.py
+++ b/tools/cbt/cbt/config.py
@@ -100,7 +100,7 @@ def _dumps_toml(config: dict) -> str:
             return "{ " + items + " }"
         return json.dumps(str(v))
 
-    for section in ("cbt", "paths", "conan", "cmake", "tools", "vulkan"):
+    for section in ("cbt", "paths", "conan", "cmake", "tools", "vulkan", "msvc"):
         if section in config:
             write_table(section, config[section])
     return "\n".join(lines).rstrip() + "\n"

--- a/tools/cbt/cbt/ctest.py
+++ b/tools/cbt/cbt/ctest.py
@@ -30,7 +30,7 @@ def run_tests(
     env: dict[str, str] | None,
     quiet: bool,
 ) -> None:
-    cmd = [ctest, "--test-dir", str(build_dir), "-R", regex, "--output-on-failure"]
+    cmd = [ctest, "--test-dir", str(build_dir), "-R", regex, "--output-on-failure", "-j"]
     if label:
         cmd += ["-L", label]
     if repeat:

--- a/tools/cbt/cbt/util.py
+++ b/tools/cbt/cbt/util.py
@@ -44,10 +44,10 @@ def is_windows() -> bool:
 
 
 def run(
-    cmd: Iterable[str],
-    cwd: Path | None = None,
-    env: dict[str, str] | None = None,
-    quiet: bool = False,
+        cmd: Iterable[str],
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        quiet: bool = False,
 ) -> RunResult:
     if not quiet:
         sys.stdout.write(f"$ {shlex.join(cmd)}\n")
@@ -64,6 +64,15 @@ def run(
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
 
+    class _NoopSink:
+        def write(self, _):
+            pass
+        def flush(self):
+            pass
+
+    stdout_sink = sys.stdout if not quiet else _NoopSink()
+    stderr_sink = sys.stderr if not quiet else _NoopSink()
+
     def _drain(pipe, sink, storage: list[str]) -> None:
         assert pipe is not None
         for line in pipe:
@@ -73,8 +82,8 @@ def run(
         pipe.close()
 
     threads = [
-        Thread(target=_drain, args=(process.stdout, sys.stdout, stdout_lines), daemon=True),
-        Thread(target=_drain, args=(process.stderr, sys.stderr, stderr_lines), daemon=True),
+        Thread(target=_drain, args=(process.stdout, stdout_sink, stdout_lines), daemon=True),
+        Thread(target=_drain, args=(process.stderr, stderr_sink, stderr_lines), daemon=True),
     ]
     for t in threads:
         t.start()


### PR DESCRIPTION
### Motivation
- Provide a minimal, offscreen frame source so example apps and the coroutine-based frame loop can run without a window for testing, profiling and future image export.
- Keep the public API small and reuse the existing `FrameGenerator` abstraction so existing render code needs minimal changes.

### Description
- Add `Cory::HeadlessFrameSource` (`src/Cory/Renderer/HeadlessFrameSource.hpp` and `.cpp`) which allocates offscreen color/depth/swap images, exposes a `frames()` `FrameGenerator` and submits frames without presenting via `submit()`; configuration is provided via `HeadlessFrameSourceCreateInfo` (size, formats, samples, image count).
- Update example applications to add a `--headless` flag, call `ctx().setupHeadlessDevice()` when requested, create a `HeadlessFrameSource`, and drive the existing coroutine-based frame loop from `headlessFrames_->frames()` while skipping window/ImGui/window-specific event processing (conditional code paths added to `HelloTriangle`, `CubeDemo`, `SceneGraph`, `DynamicPipeline`, and `ParticleCompute`).
- Make the triangle example pipeline constructible from explicit `colorFormat`, `depthFormat` and `sampleCount` so pipelines can be created when no `Window`/`Swapchain` is present (`examples/01-HelloTriangle/*` changes).
- Wire the new sources into the build by adding the new files to the CMake list (`src/Cory/CMakeLists.txt`).

### Testing
- No automated tests were run for this change.
- The change contains example guards to avoid touching window/ImGui code paths when headless mode is enabled to reduce risk during headless runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb0c61ffc83279bac0f3a13bf7c82)