### PR TITLE
Share FramegraphResourceManager across Framegraphs and track per-frame resources

### DIFF
--- a/examples/02-CubeDemo/src/CubeDemo.cpp
+++ b/examples/02-CubeDemo/src/CubeDemo.cpp
@@ -197,11 +197,12 @@ CubeDemoApplication::~CubeDemoApplication()
 
 void CubeDemoApplication::run()
 {
+    Cory::FramegraphResourceManager framegraphResources{ctx()};
     // one framegraph for each frame in flight
     std::vector<Cory::Framegraph> framegraphs;
     uint32_t idx = 0;
     std::generate_n(std::back_inserter(framegraphs), Cory::MAX_FRAMES_IN_FLIGHT, [&]() {
-        return Cory::Framegraph(ctx(), idx++);
+        return Cory::Framegraph(ctx(), framegraphResources, idx++);
     });
 
     auto time = getElapsedTimeSeconds();
@@ -233,7 +234,7 @@ void CubeDemoApplication::run()
         // retire old resources from the last time this framegraph was
         // used - our frame synchronization ensures that the resources
         // are no longer in use
-        fg.resetForNextFrame();
+        fg.resetForNextFrame(frameCtx.frameNumber);
 
         defineRenderPasses(fg, frameCtx);
 

--- a/examples/03-SceneGraph/src/SceneGraphDemo.cpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.cpp
@@ -13,6 +13,7 @@
 #include <Cory/Base/ResourceLocator.hpp>
 #include <Cory/Base/Time.hpp>
 #include <Cory/Framegraph/Framegraph.hpp>
+#include <Cory/Framegraph/FramegraphResourceManager.hpp>
 #include <Cory/ImGui/Inputs.hpp>
 #include <Cory/ImGui/Widgets.hpp>
 #include <Cory/RenderTasks/StandardRenderTasks.hpp>
@@ -193,11 +194,12 @@ SceneGraphDemoApplication::~SceneGraphDemoApplication()
 
 void SceneGraphDemoApplication::run()
 {
+    Cory::FramegraphResourceManager framegraphResources{ctx()};
     // one framegraph for each frame in flight
     std::vector<Cory::Framegraph> framegraphs;
     uint32_t idx = 0;
     std::generate_n(std::back_inserter(framegraphs), Cory::MAX_FRAMES_IN_FLIGHT, [&]() {
-        return Cory::Framegraph(ctx(), idx++);
+        return Cory::Framegraph(ctx(), framegraphResources, idx++);
     });
 
     auto time = Cory::AppClock::now();
@@ -229,7 +231,7 @@ void SceneGraphDemoApplication::run()
         // retire old resources from the last time this framegraph was
         // used - our frame synchronization ensures that the resources
         // are no longer in use
-        fg.resetForNextFrame();
+        fg.resetForNextFrame(frameCtx.frameNumber);
 
         defineRenderPasses(fg, frameCtx);
 

--- a/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
+++ b/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
@@ -13,6 +13,7 @@
 #include <Cory/Base/Time.hpp>
 #include <Cory/Cory.hpp>
 #include <Cory/Framegraph/Framegraph.hpp>
+#include <Cory/Framegraph/FramegraphResourceManager.hpp>
 #include <Cory/ImGui/Inputs.hpp>
 #include <Cory/ImGui/Widgets.hpp>
 #include <Cory/RenderTasks/StandardRenderTasks.hpp>
@@ -159,11 +160,12 @@ ParticleComputeDemoApplication::~ParticleComputeDemoApplication()
 
 void ParticleComputeDemoApplication::run()
 {
+    Cory::FramegraphResourceManager framegraphResources{ctx()};
     // one framegraph for each frame in flight
     std::vector<Cory::Framegraph> framegraphs;
     uint32_t idx = 0;
     std::generate_n(std::back_inserter(framegraphs), Cory::MAX_FRAMES_IN_FLIGHT, [&]() {
-        return Cory::Framegraph(ctx(), idx++);
+        return Cory::Framegraph(ctx(), framegraphResources, idx++);
     });
 
     auto time = Cory::AppClock::now();
@@ -196,7 +198,7 @@ void ParticleComputeDemoApplication::run()
         // retire old resources from the last time this framegraph was
         // used - our frame synchronization ensures that the resources
         // are no longer in use
-        fg.resetForNextFrame();
+        fg.resetForNextFrame(frameCtx.frameNumber);
 
         defineRenderPasses(fg, frameCtx);
 

--- a/src/Cory/Framegraph/Framegraph.cpp
+++ b/src/Cory/Framegraph/Framegraph.cpp
@@ -30,16 +30,18 @@
 namespace Cory {
 
 struct FramegraphPrivate {
-    FramegraphPrivate(Context &ctx_param, uint32_t instanceIndex)
+    FramegraphPrivate(Context &ctx_param,
+                      FramegraphResourceManager &resources_param,
+                      uint32_t instanceIndex)
         : ctx{&ctx_param}
-        , resources{ctx_param}
+        , resources{&resources_param}
         , shaderBindingContext{
-              ctx->device(), resources, ctx->descriptors(), instanceIndex, 200 * 1024 * 1024}
+              ctx->device(), resources_param, ctx->descriptors(), instanceIndex, 200 * 1024 * 1024}
     {
     }
 
     Context *ctx;
-    FramegraphResourceManager resources;
+    FramegraphResourceManager *resources;
     ShaderBindingContext shaderBindingContext;
     std::vector<TransientTextureHandle> externalInputs;
     std::vector<TransientTextureHandle> outputs;
@@ -49,6 +51,8 @@ struct FramegraphPrivate {
     FrameContext *currentFrameCtx{};
 
     std::unordered_map<TransientTextureHandle, Sync::AccessType> outputFinalAccesses;
+    uint64_t lastFrameNumber{};
+    bool hasRecordedFrame{};
 };
 
 RenderTaskBuilder Framegraph::declareTask(std::string_view name)
@@ -57,8 +61,10 @@ RenderTaskBuilder Framegraph::declareTask(std::string_view name)
     return RenderTaskBuilder{*data_->ctx, *this, name};
 }
 
-Framegraph::Framegraph(Context &ctx, uint32_t instanceIndex)
-    : data_{std::make_unique<FramegraphPrivate>(ctx, instanceIndex)}
+Framegraph::Framegraph(Context &ctx,
+                       FramegraphResourceManager &resources,
+                       uint32_t instanceIndex)
+    : data_{std::make_unique<FramegraphPrivate>(ctx, resources, instanceIndex)}
 {
 }
 
@@ -67,7 +73,14 @@ Framegraph::~Framegraph()
     // if data_ is empty, object is moved-from
     if (data_) {
         try {
-            resetForNextFrame();
+            data_->shaderBindingContext.reset();
+            for (RenderTaskInfo &info : data_->renderTasks) { // NOLINT (false positive)
+                info.coroHandle.destroy();
+            }
+            data_->renderTasks.clear();
+            data_->externalInputs.clear();
+            data_->outputs.clear();
+            data_->outputFinalAccesses.clear();
         }
         catch (const std::exception &e) {
             CO_APP_ERROR("Uncaught exception in destructor: {}", e.what());
@@ -86,12 +99,12 @@ void Framegraph::finalizeOutputs(ExecutionInfo executionInfo)
         auto it = data_->outputFinalAccesses.find(output);
         if (it == data_->outputFinalAccesses.end()) continue;
         Sync::AccessType requestedAccess = it->second;
-        auto currentState = data_->resources.state(output);
+        auto currentState = data_->resources->state(output);
         Sync::AccessType lastAccess = currentState.lastAccess;
         // Only add a barrier if the access actually changes
         if (lastAccess != requestedAccess) {
-            auto barrier =
-                data_->resources.synchronizeTexture(output, requestedAccess, ImageContents::Retain);
+            auto barrier = data_->resources->synchronizeTexture(
+                output, requestedAccess, ImageContents::Retain);
             outputBarriers.push_back(barrier);
             // Record the transition in the execution info
             executionInfo.transitions.push_back(
@@ -114,6 +127,9 @@ void Framegraph::finalizeOutputs(ExecutionInfo executionInfo)
 ExecutionInfo Framegraph::record(FrameContext &frameCtx)
 {
     const Cory::ScopeTimer s1{"Framegraph/Execute"};
+    data_->resources->setCurrentFrameNumber(frameCtx.frameNumber);
+    data_->lastFrameNumber = frameCtx.frameNumber;
+    data_->hasRecordedFrame = true;
     auto executionInfo = compile();
 
     const Cory::ScopeTimer s2{"Framegraph/Execute/Record"};
@@ -137,12 +153,16 @@ ExecutionInfo Framegraph::record(FrameContext &frameCtx)
     return executionInfo;
 }
 
-void Framegraph::resetForNextFrame()
+void Framegraph::resetForNextFrame(uint64_t frameNumber)
 {
     data_->shaderBindingContext.reset();
-    data_->resources.clear();
+    if (data_->hasRecordedFrame) {
+        data_->resources->clearFrame(data_->lastFrameNumber);
+    }
+    data_->resources->setCurrentFrameNumber(frameNumber);
     data_->externalInputs.clear();
     data_->outputs.clear();
+    data_->outputFinalAccesses.clear();
 
     for (RenderTaskInfo &info : data_->renderTasks) { // NOLINT (false positive)
         info.coroHandle.destroy();
@@ -163,7 +183,7 @@ Framegraph::PassTransitions Framegraph::executePass(CommandRecorder &cmd, Render
                 .kind = resourceInfo.kind,
                 .task = handle,
                 .resource = resourceInfo.handle,
-                .stateBefore = data_->resources.state(resourceInfo.handle).lastAccess,
+                .stateBefore = data_->resources->state(resourceInfo.handle).lastAccess,
                 .stateAfter = resourceInfo.access});
 
             // only discard if it is not a read/write dependency
@@ -171,7 +191,7 @@ Framegraph::PassTransitions Framegraph::executePass(CommandRecorder &cmd, Render
                                           ? ImageContents::Retain
                                           : ImageContents::Discard;
 
-            return data_->resources.synchronizeTexture(
+            return data_->resources->synchronizeTexture(
                 resourceInfo.handle, resourceInfo.access, contentsMode);
         };
 
@@ -180,10 +200,10 @@ Framegraph::PassTransitions Framegraph::executePass(CommandRecorder &cmd, Render
                 .kind = resourceInfo.kind,
                 .task = handle,
                 .resource = resourceInfo.handle,
-                .stateBefore = data_->resources.state(resourceInfo.handle).lastAccess,
+                .stateBefore = data_->resources->state(resourceInfo.handle).lastAccess,
                 .stateAfter = resourceInfo.access});
 
-            return data_->resources.synchronizeBuffer(resourceInfo.handle, resourceInfo.access);
+            return data_->resources->synchronizeBuffer(resourceInfo.handle, resourceInfo.access);
         };
 
         // fill the barriers from the inputs and outputs
@@ -269,7 +289,7 @@ TransientTextureHandle Framegraph::declareInput(TextureInfo info,
                                                 const TextureView &imageView)
 {
     auto handle =
-        data_->resources.registerExternal(std::move(info), lastWriteAccess, image, imageView);
+        data_->resources->registerExternal(std::move(info), lastWriteAccess, image, imageView);
 
     TransientTextureHandle thandle{handle};
 
@@ -282,7 +302,7 @@ std::pair<TextureInfo, TextureState> Framegraph::declareOutput(TransientTextureH
 {
     data_->outputs.push_back(handle);
     data_->outputFinalAccesses[handle] = finalAccess;
-    return {data_->resources.info(handle), data_->resources.state(handle)};
+    return {data_->resources->info(handle), data_->resources->state(handle)};
 }
 
 ExecutionInfo Framegraph::compile()
@@ -290,8 +310,8 @@ ExecutionInfo Framegraph::compile()
     const Cory::ScopeTimer s{"Framegraph/Execute/Compile"};
 
     auto execInfo = resolve(data_->outputs);
-    data_->resources.allocate(execInfo.resources);
-    data_->resources.allocate(execInfo.buffers);
+    data_->resources->allocate(execInfo.resources);
+    data_->resources->allocate(execInfo.buffers);
 
     return std::move(execInfo);
 }
@@ -317,11 +337,11 @@ void Framegraph::enqueueRenderPass(RenderTaskHandle passHandle,
 
 FramegraphResourceManager &Framegraph::resources()
 {
-    return data_->resources;
+    return *data_->resources;
 }
 const FramegraphResourceManager &Framegraph::resources() const
 {
-    return data_->resources;
+    return *data_->resources;
 }
 const std::vector<TransientTextureHandle> &Framegraph::externalInputs() const
 {
@@ -355,7 +375,7 @@ ExecutionInfo Framegraph::resolve(const std::vector<TransientTextureHandle> &req
             if (kind.is_set(TaskDependencyKindBits::Write)) {
                 textureToTask[dependency.handle] = taskHandle;
             }
-            textures[dependency.handle] = data_->resources.info(dependency.handle);
+            textures[dependency.handle] = data_->resources->info(dependency.handle);
         }
         for (const RenderTaskInfo::BufferDependency &dependency : taskInfo.bufferDependencies) {
             const auto kind = dependency.kind;
@@ -366,7 +386,7 @@ ExecutionInfo Framegraph::resolve(const std::vector<TransientTextureHandle> &req
             if (kind.is_set(TaskDependencyKindBits::Write)) {
                 bufferToTask[dependency.handle] = taskHandle;
             }
-            buffers[dependency.handle] = data_->resources.info(dependency.handle);
+            buffers[dependency.handle] = data_->resources->info(dependency.handle);
         }
     }
 
@@ -649,7 +669,7 @@ RenderInput Framegraph::renderInput(RenderTaskHandle taskHandle)
     return {
         .ctx = data_->ctx,
         .frameCtx = data_->currentFrameCtx,
-        .resources = &data_->resources,
+        .resources = data_->resources,
         .bindingContext = &data_->shaderBindingContext,
         .cmd = data_->commandListInProgress,
     };

--- a/src/Cory/Framegraph/Framegraph.hpp
+++ b/src/Cory/Framegraph/Framegraph.hpp
@@ -41,7 +41,9 @@ class Framegraph : NoCopy {
   public:
     // Create a new framegraph with the given context, using the given instance index for resource
     // allocation
-    explicit Framegraph(Context &ctx, uint32_t instanceIndex);
+    explicit Framegraph(Context &ctx,
+                        FramegraphResourceManager &resources,
+                        uint32_t instanceIndex);
     ~Framegraph();
 
     Framegraph(Framegraph &&) noexcept;
@@ -60,7 +62,7 @@ class Framegraph : NoCopy {
      * should be called only when it can be ensured that all resources are no longer in use, e.g.
      * for example when the next frame with the same swapchain image has been rendered.
      */
-    void resetForNextFrame();
+    void resetForNextFrame(uint64_t frameNumber);
 
     /// declare a new render task
     RenderTaskBuilder declareTask(std::string_view name);

--- a/src/Cory/Framegraph/FramegraphResourceManager.cpp
+++ b/src/Cory/Framegraph/FramegraphResourceManager.cpp
@@ -12,6 +12,8 @@
 
 #include <gsl/narrow>
 
+#include <vector>
+
 namespace Cory {
 
 struct TextureResource {
@@ -19,18 +21,21 @@ struct TextureResource {
     TextureState state;
     Gpu::TextureHandle image;
     Gpu::TextureViewHandle view;
+    uint64_t lastUsedFrameNumber{0};
 };
 
 struct BufferResource {
     BufferInfo info;
     BufferState state;
     Gpu::BufferHandle buffer;
+    uint64_t lastUsedFrameNumber{0};
 };
 
 struct FramegraphResourceManagerPrivate {
     Context *ctx_{};
     SlotMap<TextureResource> textureResources_;
     SlotMap<BufferResource> bufferResources_;
+    uint64_t currentFrameNumber{};
 };
 
 FramegraphResourceManager::FramegraphResourceManager(Context &ctx)
@@ -39,11 +44,24 @@ FramegraphResourceManager::FramegraphResourceManager(Context &ctx)
     data_->ctx_ = &ctx;
 }
 
-FramegraphResourceManager::~FramegraphResourceManager() = default;
+FramegraphResourceManager::~FramegraphResourceManager()
+{
+    clearAll();
+}
 FramegraphResourceManager::FramegraphResourceManager(FramegraphResourceManager &&) noexcept =
     default;
 FramegraphResourceManager &
 FramegraphResourceManager::operator=(FramegraphResourceManager &&) noexcept = default;
+
+void FramegraphResourceManager::setCurrentFrameNumber(uint64_t frameNumber)
+{
+    data_->currentFrameNumber = frameNumber;
+}
+
+uint64_t FramegraphResourceManager::currentFrameNumber() const
+{
+    return data_->currentFrameNumber;
+}
 
 FramegraphTextureHandle FramegraphResourceManager::declareTexture(TextureInfo info)
 {
@@ -57,7 +75,8 @@ FramegraphTextureHandle FramegraphResourceManager::declareTexture(TextureInfo in
         info,
         TextureState{.lastAccess = Sync::AccessType::None, .status = TextureMemoryStatus::Virtual},
         Gpu::Texture{},
-        Gpu::TextureView{}});
+        Gpu::TextureView{},
+        data_->currentFrameNumber});
     return handle;
 }
 
@@ -72,7 +91,8 @@ FramegraphResourceManager::registerExternal(TextureInfo info,
                         .state = TextureState{.lastAccess = lastWriteAccess,
                                               .status = TextureMemoryStatus::External},
                         .image = resource,
-                        .view = resourceView});
+                        .view = resourceView,
+                        .lastUsedFrameNumber = data_->currentFrameNumber});
 
     return handle;
 }
@@ -149,7 +169,8 @@ Sync::ImageBarrier FramegraphResourceManager::synchronizeTexture(FramegraphTextu
 {
     const auto &info = data_->textureResources_[handle].info;
     auto aspectMask = flagsForFormat(info.format);
-    auto &state = data_->textureResources_[handle].state;
+    auto &resource = data_->textureResources_[handle];
+    auto &state = resource.state;
 
     auto *texture = data_->ctx_->resources().getTexture(image(handle));
     CO_CORE_DEBUG_ASSERT(texture != nullptr, "Texture resource is null");
@@ -179,6 +200,7 @@ Sync::ImageBarrier FramegraphResourceManager::synchronizeTexture(FramegraphTextu
                   access);
 
     state.lastAccess = access;
+    resource.lastUsedFrameNumber = data_->currentFrameNumber;
     return barrier;
 }
 
@@ -210,7 +232,8 @@ FramegraphBufferHandle FramegraphResourceManager::declareBuffer(BufferInfo info)
         BufferResource{.info = std::move(info),
                        .state = BufferState{.lastAccess = Sync::AccessType::None,
                                             .status = BufferMemoryStatus::Virtual},
-                       .buffer = Gpu::Buffer{}});
+                       .buffer = Gpu::Buffer{},
+                       .lastUsedFrameNumber = data_->currentFrameNumber});
     return handle;
 }
 
@@ -221,7 +244,8 @@ FramegraphBufferHandle FramegraphResourceManager::registerExternal(BufferInfo in
     auto handle = data_->bufferResources_.emplace(BufferResource{
         .info = std::move(info),
         .state = BufferState{.lastAccess = lastWriteAccess, .status = BufferMemoryStatus::External},
-        .buffer = resource});
+        .buffer = resource,
+        .lastUsedFrameNumber = data_->currentFrameNumber});
     return handle;
 }
 
@@ -258,7 +282,8 @@ void FramegraphResourceManager::allocate(const std::vector<FramegraphBufferHandl
 Sync::BufferBarrier FramegraphResourceManager::synchronizeBuffer(FramegraphBufferHandle handle,
                                                                  Sync::AccessType access)
 {
-    auto &state = data_->bufferResources_[handle].state;
+    auto &resource = data_->bufferResources_[handle];
+    auto &state = resource.state;
     auto *bufferResource = data_->ctx_->resources().getBuffer(buffer(handle));
     CO_CORE_DEBUG_ASSERT(bufferResource != nullptr, "Buffer resource is null");
 
@@ -276,6 +301,7 @@ Sync::BufferBarrier FramegraphResourceManager::synchronizeBuffer(FramegraphBuffe
                   access);
 
     state.lastAccess = access;
+    resource.lastUsedFrameNumber = data_->currentFrameNumber;
     return barrier;
 }
 
@@ -312,22 +338,72 @@ BufferState FramegraphResourceManager::state(FramegraphBufferHandle handle) cons
     return data_->bufferResources_[handle].state;
 }
 
-void FramegraphResourceManager::clear()
+void FramegraphResourceManager::clearFrame(uint64_t frameNumber)
 {
-    for (auto &res : data_->textureResources_) {
-        if (res.state.status == TextureMemoryStatus::Allocated) {
-            data_->ctx_->resources().deleteTexture(res.image);
-            data_->ctx_->resources().deleteTextureView(res.view);
-        }
+    if (!data_) {
+        return;
     }
-    data_->textureResources_.clear();
+    std::vector<FramegraphTextureHandle> textureHandlesToRelease;
+    for (const auto &handle : data_->textureResources_.handles()) {
+        const auto &resource = data_->textureResources_[handle];
+        if (resource.lastUsedFrameNumber != frameNumber) {
+            continue;
+        }
+        if (resource.state.status == TextureMemoryStatus::Allocated) {
+            data_->ctx_->resources().deleteTexture(resource.image);
+            data_->ctx_->resources().deleteTextureView(resource.view);
+        }
+        textureHandlesToRelease.push_back(handle);
+    }
+    for (const auto &handle : textureHandlesToRelease) {
+        data_->textureResources_.release(handle);
+    }
 
-    for (auto &res : data_->bufferResources_) {
-        if (res.state.status == BufferMemoryStatus::Allocated) {
-            data_->ctx_->resources().deleteBuffer(res.buffer);
+    std::vector<FramegraphBufferHandle> bufferHandlesToRelease;
+    for (const auto &handle : data_->bufferResources_.handles()) {
+        const auto &resource = data_->bufferResources_[handle];
+        if (resource.lastUsedFrameNumber != frameNumber) {
+            continue;
         }
+        if (resource.state.status == BufferMemoryStatus::Allocated) {
+            data_->ctx_->resources().deleteBuffer(resource.buffer);
+        }
+        bufferHandlesToRelease.push_back(handle);
     }
-    data_->bufferResources_.clear();
+    for (const auto &handle : bufferHandlesToRelease) {
+        data_->bufferResources_.release(handle);
+    }
+}
+
+void FramegraphResourceManager::clearAll()
+{
+    if (!data_) {
+        return;
+    }
+    std::vector<FramegraphTextureHandle> textureHandlesToRelease;
+    for (const auto &handle : data_->textureResources_.handles()) {
+        const auto &resource = data_->textureResources_[handle];
+        if (resource.state.status == TextureMemoryStatus::Allocated) {
+            data_->ctx_->resources().deleteTexture(resource.image);
+            data_->ctx_->resources().deleteTextureView(resource.view);
+        }
+        textureHandlesToRelease.push_back(handle);
+    }
+    for (const auto &handle : textureHandlesToRelease) {
+        data_->textureResources_.release(handle);
+    }
+
+    std::vector<FramegraphBufferHandle> bufferHandlesToRelease;
+    for (const auto &handle : data_->bufferResources_.handles()) {
+        const auto &resource = data_->bufferResources_[handle];
+        if (resource.state.status == BufferMemoryStatus::Allocated) {
+            data_->ctx_->resources().deleteBuffer(resource.buffer);
+        }
+        bufferHandlesToRelease.push_back(handle);
+    }
+    for (const auto &handle : bufferHandlesToRelease) {
+        data_->bufferResources_.release(handle);
+    }
 }
 
 } // namespace Cory

--- a/src/Cory/Framegraph/FramegraphResourceManager.hpp
+++ b/src/Cory/Framegraph/FramegraphResourceManager.hpp
@@ -34,6 +34,9 @@ class FramegraphResourceManager : NoCopy {
     explicit FramegraphResourceManager(FramegraphResourceManager &&) noexcept;
     FramegraphResourceManager &operator=(FramegraphResourceManager &&) noexcept;
 
+    void setCurrentFrameNumber(uint64_t frameNumber);
+    [[nodiscard]] uint64_t currentFrameNumber() const;
+
     // Declare a new texture - will only create the metadata, not allocate the actual resource
     FramegraphTextureHandle declareTexture(TextureInfo info);
 
@@ -90,7 +93,8 @@ class FramegraphResourceManager : NoCopy {
     [[nodiscard]] BufferDeviceAddress deviceAddress(FramegraphBufferHandle handle) const;
     [[nodiscard]] BufferState state(FramegraphBufferHandle handle) const;
 
-    void clear();
+    void clearFrame(uint64_t frameNumber);
+    void clearAll();
 
   private:
     void allocate(FramegraphTextureHandle handle);

--- a/tests/FrameGraph_Test.cpp
+++ b/tests/FrameGraph_Test.cpp
@@ -4,6 +4,7 @@
 
 #include <Cory/Base/FmtUtils.hpp>
 #include <Cory/Framegraph/Framegraph.hpp>
+#include <Cory/Framegraph/FramegraphResourceManager.hpp>
 #include <Cory/Framegraph/RenderTaskBuilder.hpp>
 #include <Cory/Framegraph/RenderTaskDeclaration.hpp>
 #include <Cory/Renderer/FrameContext.hpp>
@@ -470,7 +471,8 @@ TEST_CASE("Framegraph API", "[Cory/Framegraph]")
 {
     testing::VulkanTester t;
 
-    Framegraph graph(t.ctx(), 0);
+    FramegraphResourceManager framegraphResources(t.ctx());
+    Framegraph graph(t.ctx(), framegraphResources, 0);
 
     auto &device = t.ctx().device();
 
@@ -532,7 +534,8 @@ TEST_CASE("Framegraph API", "[Cory/Framegraph]")
 TEST_CASE("Framegraph allocates temp resources for scheduled tasks", "[Cory/Framegraph]")
 {
     testing::VulkanTester t;
-    Framegraph graph(t.ctx(), 0);
+    FramegraphResourceManager framegraphResources(t.ctx());
+    Framegraph graph(t.ctx(), framegraphResources, 0);
 
     auto pass = passes::tempResourcePass(graph.declareTask("PASS_TempResource"), {128, 128, 1});
     auto [outputInfo, outputState] =
@@ -611,7 +614,8 @@ RenderTaskDeclaration<MainSubtaskOut> mainPassWithSubpasses(RenderTaskBuilder bu
 TEST_CASE("Framegraph subtask definition", "[Cory/Framegraph]")
 {
     testing::VulkanTester t;
-    Framegraph graph(t.ctx(), 0);
+    FramegraphResourceManager framegraphResources(t.ctx());
+    Framegraph graph(t.ctx(), framegraphResources, 0);
 
     auto prevFrame = createGraphInput(t.ctx().device(), graph);
 
@@ -644,7 +648,8 @@ TEST_CASE("Framegraph subtask definition", "[Cory/Framegraph]")
 TEST_CASE("Framegraph resolve avoids repeated buffer visits", "[Cory/Framegraph]")
 {
     testing::VulkanTester t;
-    Framegraph graph(t.ctx(), 0);
+    FramegraphResourceManager framegraphResources(t.ctx());
+    Framegraph graph(t.ctx(), framegraphResources, 0);
 
     auto shared = passes::sharedBufferProducer(graph.declareTask("PASS_SharedBuffer"));
     auto consumerA = passes::bufferConsumer(graph.declareTask("PASS_ConsumerA"),
@@ -691,7 +696,8 @@ TEST_CASE("Framegraph resolve avoids repeated buffer visits", "[Cory/Framegraph]
 TEST_CASE("Framegraph resolves toy radix ordering", "[Cory/Framegraph]")
 {
     testing::VulkanTester t;
-    Framegraph graph(t.ctx(), 0);
+    FramegraphResourceManager framegraphResources(t.ctx());
+    Framegraph graph(t.ctx(), framegraphResources, 0);
 
     auto radixTask = passes::toyRadix(graph.declareTask("TASK_ToyRadix"));
     auto sinkTask = passes::toySink(graph.declareTask("TASK_ToySink"), radixTask.output().indices);

--- a/tests/FramegraphResourceManager_Test.cpp
+++ b/tests/FramegraphResourceManager_Test.cpp
@@ -35,7 +35,6 @@ TEST_CASE("Framegraph resource manager tracks textures and buffers",
         CHECK(resources.image(texHandle).isValid());
         CHECK(resources.imageView(texHandle).isValid());
 
-
         Texture externalTexture = device.createTexture(Gpu::TextureOptions{
             .label = "TEX_External (IMG)",
             .type = Gpu::TextureType::TextureType2D,
@@ -104,5 +103,5 @@ TEST_CASE("Framegraph resource manager tracks textures and buffers",
         CHECK(resources.buffer(externalBufferHandle) == externalBuffer.handle());
     }
     // Cleanup
-    resources.clear();
+    resources.clearAll();
 }

--- a/tests/LayerStack_Test.cpp
+++ b/tests/LayerStack_Test.cpp
@@ -3,6 +3,7 @@
 #include <Cory/Application/ApplicationLayer.hpp>
 #include <Cory/Application/LayerStack.hpp>
 #include <Cory/Framegraph/Framegraph.hpp>
+#include <Cory/Framegraph/FramegraphResourceManager.hpp>
 #include <Cory/Framegraph/RenderTaskBuilder.hpp>
 
 #include "TestUtils.hpp"
@@ -149,7 +150,8 @@ TEST_CASE("LayerStack", "[LayerStack]")
         }
         WHEN("Enqueueing the render tasks")
         {
-            Cory::Framegraph framegraph(tester.ctx(), 0);
+            Cory::FramegraphResourceManager framegraphResources(tester.ctx());
+            Cory::Framegraph framegraph(tester.ctx(), framegraphResources, 0);
 
             SECTION("No layers have a render task")
             {

--- a/tests/RadixSort_Test.cpp
+++ b/tests/RadixSort_Test.cpp
@@ -3,6 +3,7 @@
 #include <../src/Cory/Renderer/RadixSorter.hpp>
 #include <Cory/Base/ResourceLocator.hpp>
 #include <Cory/Framegraph/Framegraph.hpp>
+#include <Cory/Framegraph/FramegraphResourceManager.hpp>
 #include <Cory/Framegraph/RenderTaskBuilder.hpp>
 #include <Cory/Framegraph/RenderTaskDeclaration.hpp>
 #include <Cory/Renderer/Context.hpp>
@@ -65,7 +66,8 @@ TEST_CASE("Radix sorter can be scheduled via framegraph")
 {
     Cory::testing::VulkanTester t;
     auto &ctx = t.ctx();
-    FramegraphTestAdapter graph(ctx, 0);
+    Cory::FramegraphResourceManager graphResources(ctx);
+    FramegraphTestAdapter graph(ctx, graphResources, 0);
 
     const auto shaderDir = fs::path{__FILE__}.parent_path().parent_path() / "data/shaders";
     Cory::ResourceLocator::addSearchPath(shaderDir);


### PR DESCRIPTION
### Motivation
- Introduce a single shared `FramegraphResourceManager` to be used by all `Framegraph` instances so resources can be shared across frames rather than owned per-frame.
- Ensure resources are only retired when the frame that used them is known to have completed by tracking a per-resource frame number instead of blunt `clear()` of all resources.
- Allow the framegraph to inform the resource manager about the current frame number so synchronization and clear semantics are frame-aware.

### Description
- Added `FramegraphResourceManager::setCurrentFrameNumber` and `currentFrameNumber`, tracked `lastUsedFrameNumber` on texture/buffer resources, and updated `synchronizeTexture`/`synchronizeBuffer` to update that field.
- Added `clearFrame(uint64_t)` to retire only resources that were last used by a particular frame and `clearAll()` to fully release everything, and call `clearAll()` in the resource manager destructor.
- Changed `Framegraph` to accept an external `FramegraphResourceManager&` in its constructor, store it as a pointer, and call `resources()->setCurrentFrameNumber` in `record` and `resources()->clearFrame` during `resetForNextFrame`; updated `resetForNextFrame` to accept a `uint64_t frameNumber` parameter.
- Adjusted framegraph APIs that access resources (e.g. `declareInput`, `declareOutput`, `compile`, `renderInput`) to use the injected resource manager pointer and cleaned up framegraph internal state handling.
- Updated sample applications (`examples/02-CubeDemo`, `examples/03-SceneGraph`, `examples/05-ParticleCompute`) to create a shared `FramegraphResourceManager` and pass it into each `Framegraph`, and to call `resetForNextFrame(frameCtx.frameNumber)`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca45a06a08327ba417deb1295598a)