### PR TITLE
Add VK_EXT_device_memory_report support and ImGui memory-report window

### DIFF
--- a/examples/02-CubeDemo/src/CubeDemo.cpp
+++ b/examples/02-CubeDemo/src/CubeDemo.cpp
@@ -481,6 +481,9 @@ void CubeDemoApplication::drawImguiControls()
         CoImGui::drawProfilerRecords(records);
     }
     ImGui::End();
+
+    memoryReportHistory_.update(ctx().deviceMemoryReportStats(), getElapsedTimeSeconds());
+    memoryReportHistory_.drawWindow();
 }
 
 void CubeDemoApplication::setupCameraCallbacks()

--- a/examples/02-CubeDemo/src/CubeDemo.hpp
+++ b/examples/02-CubeDemo/src/CubeDemo.hpp
@@ -6,6 +6,7 @@
 #include <Cory/Application/DynamicGeometry.hpp>
 #include <Cory/Framegraph/Common.hpp>
 #include <Cory/Framegraph/RenderTaskDeclaration.hpp>
+#include <Cory/ImGui/Widgets.hpp>
 #include <Cory/Renderer/Common.hpp>
 
 #include <glm/mat4x4.hpp>
@@ -94,4 +95,5 @@ class CubeDemoApplication : public Cory::Application {
     Cory::CameraManipulator camera_;
     std::vector<InstanceBuffer> instanceBuffers_;
     std::vector<InstanceData> instanceData_;
+    CoImGui::DeviceMemoryReportHistory memoryReportHistory_{};
 };

--- a/examples/03-SceneGraph/src/SceneGraphDemo.cpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.cpp
@@ -319,4 +319,8 @@ void SceneGraphDemoApplication::drawImguiControls()
         CoImGui::drawProfilerRecords(records);
     }
     ImGui::End();
+
+    memoryReportHistory_.update(ctx().deviceMemoryReportStats(),
+                                clock_.lastTick().now.time_since_epoch().count());
+    memoryReportHistory_.drawWindow();
 }

--- a/examples/03-SceneGraph/src/SceneGraphDemo.hpp
+++ b/examples/03-SceneGraph/src/SceneGraphDemo.hpp
@@ -4,6 +4,7 @@
 #include <Cory/Application/Common.hpp>
 #include <Cory/Base/SimulationClock.hpp>
 #include <Cory/Framegraph/Common.hpp>
+#include <Cory/ImGui/Widgets.hpp>
 #include <Cory/Renderer/Common.hpp>
 #include <Cory/SceneGraph/SceneGraph.hpp>
 #include <Cory/Systems/SystemCoordinator.hpp>
@@ -42,6 +43,7 @@ class SceneGraphDemoApplication : public Cory::Application {
     Cory::SystemCoordinator systems_;
     class CubeAnimationSystem *animationSystem_{nullptr};
     class CubeRenderSystem *renderSystem_{nullptr};
+    CoImGui::DeviceMemoryReportHistory memoryReportHistory_{};
     void setupSystems();
     void setupScene();
 };

--- a/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
+++ b/examples/04-DynamicPipeline/src/DynamicPipelineApplication.cpp
@@ -524,6 +524,9 @@ void DynamicPipelineApplication::drawUi(const Cory::FrameContext &frameCtx)
         }
     }
     ImGui::End();
+
+    memoryReportHistory_.update(ctx().deviceMemoryReportStats(), getElapsedTimeSeconds());
+    memoryReportHistory_.drawWindow();
 }
 
 bool DynamicPipelineApplication::compileFragmentShaderSource(std::string_view sourceText,

--- a/examples/04-DynamicPipeline/src/DynamicPipelineApplication.hpp
+++ b/examples/04-DynamicPipeline/src/DynamicPipelineApplication.hpp
@@ -3,6 +3,7 @@
 #include <Cory/Application/Application.hpp>
 #include <Cory/Application/DynamicGeometry.hpp>
 #include <Cory/Base/Coro.hpp>
+#include <Cory/ImGui/Widgets.hpp>
 #include <Cory/Renderer/Gpu.hpp>
 #include <Cory/Renderer/Shader.hpp>
 
@@ -95,6 +96,7 @@ class DynamicPipelineApplication : public Cory::Application {
     DynamicStateSettings settings_{};
     std::vector<Gpu::TextureLayout> swapchainLayouts_;
     std::vector<Gpu::TextureLayout> depthLayouts_;
+    CoImGui::DeviceMemoryReportHistory memoryReportHistory_{};
 
     void resetAttachmentLayouts();
     void transitionColorAttachmentForRender(Cory::FrameContext &frameCtx);

--- a/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
+++ b/examples/05-ParticleCompute/src/ParticleComputeDemo.cpp
@@ -286,4 +286,8 @@ void ParticleComputeDemoApplication::drawImguiControls()
         CoImGui::drawProfilerRecords(records);
     }
     ImGui::End();
+
+    memoryReportHistory_.update(ctx().deviceMemoryReportStats(),
+                                clock_.lastTick().now.time_since_epoch().count());
+    memoryReportHistory_.drawWindow();
 }

--- a/examples/05-ParticleCompute/src/ParticleComputeDemo.hpp
+++ b/examples/05-ParticleCompute/src/ParticleComputeDemo.hpp
@@ -4,6 +4,7 @@
 #include <Cory/Application/Common.hpp>
 #include <Cory/Base/SimulationClock.hpp>
 #include <Cory/Framegraph/Common.hpp>
+#include <Cory/ImGui/Widgets.hpp>
 #include <Cory/Renderer/Common.hpp>
 #include <Cory/SceneGraph/SceneGraph.hpp>
 #include <Cory/Systems/SystemCoordinator.hpp>
@@ -41,6 +42,7 @@ class ParticleComputeDemoApplication : public Cory::Application {
     Cory::SceneGraph sceneGraph_;
     Cory::SystemCoordinator systems_;
     class PointSpriteRenderSystem *renderSystem_{nullptr};
+    CoImGui::DeviceMemoryReportHistory memoryReportHistory_{};
     void setupSystems();
     void setupScene();
 };

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -37,12 +37,14 @@ if (KDGPU_SOURCE_DIR)
     FetchContent_Declare(
             KDGpu
             SOURCE_DIR "${KDGPU_SOURCE_DIR}"
+            PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_LIST_DIR}/patches/kdgpu-device-memory-report.patch
     )
 else ()
     FetchContent_Declare(
             KDGpu
             GIT_REPOSITORY https://github.com/TheHugeManatee/KDGpu.git
             GIT_TAG main
+            PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_LIST_DIR}/patches/kdgpu-device-memory-report.patch
     )
 endif ()
 FetchContent_MakeAvailable(KDGpu)

--- a/external/patches/kdgpu-device-memory-report.patch
+++ b/external/patches/kdgpu-device-memory-report.patch
@@ -1,0 +1,71 @@
+diff --git a/src/KDGpu/device_options.h b/src/KDGpu/device_options.h
+index 3d2d8dd..6e67a18 100644
+--- a/src/KDGpu/device_options.h
++++ b/src/KDGpu/device_options.h
+@@ -17,6 +17,8 @@
+ #include <string>
+ #include <vector>
+ 
++struct VkDeviceMemoryReportCallbackDataEXT;
++
+ namespace KDGpu {
+ 
+ struct QueueRequest {
+@@ -35,6 +37,9 @@ struct DeviceOptions {
+     std::vector<QueueRequest> queues;
+     AdapterFeatures requestedFeatures;
+     AdapterGroup adapterGroup;
++    using DeviceMemoryReportCallback = void (*)(const VkDeviceMemoryReportCallbackDataEXT *, void *);
++    DeviceMemoryReportCallback deviceMemoryReportCallback{nullptr};
++    void *deviceMemoryReportUserData{nullptr};
+ };
+ 
+ } // namespace KDGpu
+diff --git a/src/KDGpu/vulkan/vulkan_resource_manager.cpp b/src/KDGpu/vulkan/vulkan_resource_manager.cpp
+index 18f36df..6d8c4b0 100644
+--- a/src/KDGpu/vulkan/vulkan_resource_manager.cpp
++++ b/src/KDGpu/vulkan/vulkan_resource_manager.cpp
+@@ -390,6 +390,37 @@ Handle<Device_t> VulkanResourceManager::createDevice(const Handle<Adapter_t> &ad
+     }
+ #endif
+ 
++#if defined(VK_EXT_device_memory_report)
++    VkDeviceDeviceMemoryReportCreateInfoEXT deviceMemoryReportCreateInfo{};
++    VkPhysicalDeviceDeviceMemoryReportFeaturesEXT deviceMemoryReportFeatures{};
++    if (options.deviceMemoryReportCallback) {
++        if (!hasExtension(availableDeviceExtensions, VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME)) {
++            SPDLOG_LOGGER_WARN(Logger::logger(),
++                               "Device memory report callback set, but VK_EXT_device_memory_report is not supported.");
++        } else {
++            VkPhysicalDeviceDeviceMemoryReportFeaturesEXT memoryReportSupport{};
++            memoryReportSupport.sType =
++                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT;
++
++            VkPhysicalDeviceFeatures2 memoryReportSupportFeatures{};
++            memoryReportSupportFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
++            memoryReportSupportFeatures.pNext = &memoryReportSupport;
++            vkGetPhysicalDeviceFeatures2(vulkanAdapter->physicalDevice, &memoryReportSupportFeatures);
++
++            if (memoryReportSupport.deviceMemoryReport) {
++                deviceMemoryReportFeatures.sType =
++                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT;
++                deviceMemoryReportFeatures.deviceMemoryReport = VK_TRUE;
++                addToChain(&deviceMemoryReportFeatures);
++
++                deviceMemoryReportCreateInfo.sType =
++                    VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT;
++                deviceMemoryReportCreateInfo.flags = 0;
++                deviceMemoryReportCreateInfo.pfnUserCallback = options.deviceMemoryReportCallback;
++                deviceMemoryReportCreateInfo.pUserData = options.deviceMemoryReportUserData;
++                addToChain(&deviceMemoryReportCreateInfo);
++            } else {
++                SPDLOG_LOGGER_WARN(Logger::logger(),
++                                   "Device memory report callback set, but deviceMemoryReport feature is not supported.");
++            }
++        }
++    }
++#endif
++
+     // Create a Device that targets several physical devices if a group was specified.
+     // We only add the device group info if we have more than one adapter.
+     VkDeviceGroupDeviceCreateInfo deviceGroupInfo = {};

--- a/src/Cory/ImGui/Widgets.cpp
+++ b/src/Cory/ImGui/Widgets.cpp
@@ -2,6 +2,9 @@
 
 #include <Cory/ImGui/Inputs.hpp>
 
+#include <algorithm>
+#include <limits>
+
 #include <gsl/narrow>
 #include <imgui.h>
 #include <range/v3/range/conversion.hpp>
@@ -43,5 +46,143 @@ void drawProfilerRecords(const std::map<std::string, Cory::Profiler::Record> &re
         }
         ImGui::EndTable();
     }
+}
+
+namespace {
+
+template <typename T> void pushSample(std::vector<T> &samples, T value, size_t maxSamples)
+{
+    samples.push_back(value);
+    if (samples.size() > maxSamples) {
+        samples.erase(samples.begin(), samples.begin() + (samples.size() - maxSamples));
+    }
+}
+
+float maxOrDefault(const std::vector<float> &values, float fallback)
+{
+    if (values.empty()) {
+        return fallback;
+    }
+    return std::max(fallback, *std::max_element(values.begin(), values.end()));
+}
+
+} // namespace
+
+void DeviceMemoryReportHistory::update(const Cory::DeviceMemoryReportStats &stats, double nowSeconds)
+{
+    if (!stats.supported) {
+        hasSamples = false;
+        return;
+    }
+
+    if (hasSamples && (nowSeconds - lastSampleTime) < sampleIntervalSeconds) {
+        return;
+    }
+
+    lastSampleTime = nowSeconds;
+    latestStats = stats;
+    hasSamples = true;
+
+    const auto bytesToMiB = [](uint64_t bytes) {
+        return static_cast<float>(bytes) / (1024.0f * 1024.0f);
+    };
+
+    pushSample(currentBytesMiB, bytesToMiB(stats.currentBytes), maxSamples);
+    pushSample(totalAllocatedMiB, bytesToMiB(stats.totalAllocatedBytes), maxSamples);
+    pushSample(allocationCounts, static_cast<float>(stats.allocationCount), maxSamples);
+    pushSample(allocationFailures, static_cast<float>(stats.allocationFailedCount), maxSamples);
+}
+
+void DeviceMemoryReportHistory::drawWindow(const char *title) const
+{
+    if (!ImGui::Begin(title)) {
+        ImGui::End();
+        return;
+    }
+
+    if (!hasSamples) {
+        ImGui::TextDisabled("Device memory report extension is not available.");
+        ImGui::End();
+        return;
+    }
+
+    const auto bytesToMiB = [](uint64_t bytes) {
+        return static_cast<float>(bytes) / (1024.0f * 1024.0f);
+    };
+
+    ImGui::Text("Sample interval: %.0f ms", sampleIntervalSeconds * 1000.0);
+    ImGui::Separator();
+    ImGui::Text("Current allocated: %.2f MiB", bytesToMiB(latestStats.currentBytes));
+    ImGui::Text("Total allocated: %.2f MiB", bytesToMiB(latestStats.totalAllocatedBytes));
+    ImGui::Text("Total freed: %.2f MiB", bytesToMiB(latestStats.totalFreedBytes));
+    ImGui::Text("Allocations: %llu", static_cast<unsigned long long>(latestStats.allocationCount));
+    ImGui::Text("Frees: %llu", static_cast<unsigned long long>(latestStats.freeCount));
+    ImGui::Text("Imports: %llu", static_cast<unsigned long long>(latestStats.importCount));
+    ImGui::Text("Unimports: %llu", static_cast<unsigned long long>(latestStats.unimportCount));
+    ImGui::Text("Allocation failures: %llu",
+                static_cast<unsigned long long>(latestStats.allocationFailedCount));
+
+    ImGui::Separator();
+
+    const float currentMax = maxOrDefault(currentBytesMiB, 1.0f);
+    ImGui::PlotLines("Current Allocated (MiB)",
+                     currentBytesMiB.data(),
+                     gsl::narrow<int>(currentBytesMiB.size()),
+                     0,
+                     nullptr,
+                     0.0f,
+                     currentMax);
+
+    const float allocationsMax = maxOrDefault(allocationCounts, 1.0f);
+    ImGui::PlotLines("Allocation Count",
+                     allocationCounts.data(),
+                     gsl::narrow<int>(allocationCounts.size()),
+                     0,
+                     nullptr,
+                     0.0f,
+                     allocationsMax);
+
+    const float failureMax = maxOrDefault(allocationFailures, 1.0f);
+    ImGui::PlotLines("Allocation Failures",
+                     allocationFailures.data(),
+                     gsl::narrow<int>(allocationFailures.size()),
+                     0,
+                     nullptr,
+                     0.0f,
+                     failureMax);
+
+    if (!latestStats.heaps.empty()) {
+        ImGui::Separator();
+        if (ImGui::BeginTable("MemoryReportHeaps", 6)) {
+            ImGui::TableSetupColumn("Heap");
+            ImGui::TableSetupColumn("Current (MiB)");
+            ImGui::TableSetupColumn("Allocated (MiB)");
+            ImGui::TableSetupColumn("Freed (MiB)");
+            ImGui::TableSetupColumn("Allocs");
+            ImGui::TableSetupColumn("Frees");
+            ImGui::TableHeadersRow();
+
+            for (const auto &heap : latestStats.heaps) {
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("%u", heap.heapIndex);
+                ImGui::TableNextColumn();
+                ImGui::Text("%.2f", bytesToMiB(heap.currentBytes));
+                ImGui::TableNextColumn();
+                ImGui::Text("%.2f", bytesToMiB(heap.totalAllocatedBytes));
+                ImGui::TableNextColumn();
+                ImGui::Text("%.2f", bytesToMiB(heap.totalFreedBytes));
+                ImGui::TableNextColumn();
+                ImGui::Text("%llu",
+                            static_cast<unsigned long long>(heap.allocationCount));
+                ImGui::TableNextColumn();
+                ImGui::Text("%llu", static_cast<unsigned long long>(heap.freeCount));
+            }
+
+            ImGui::EndTable();
+        }
+    }
+
+    ImGui::End();
 }
 } // namespace CoImGui

--- a/src/Cory/ImGui/Widgets.hpp
+++ b/src/Cory/ImGui/Widgets.hpp
@@ -1,9 +1,29 @@
 #pragma once
 
 #include <Cory/Base/Profiling.hpp>
+#include <Cory/Renderer/Context.hpp>
+
+#include <cstddef>
+#include <vector>
 
 namespace CoImGui {
 
 void drawProfilerRecords(const std::map<std::string, Cory::Profiler::Record> &records);
+
+struct DeviceMemoryReportHistory {
+    double sampleIntervalSeconds{0.3};
+    double lastSampleTime{0.0};
+    size_t maxSamples{120};
+    bool hasSamples{false};
+
+    Cory::DeviceMemoryReportStats latestStats{};
+    std::vector<float> currentBytesMiB;
+    std::vector<float> totalAllocatedMiB;
+    std::vector<float> allocationCounts;
+    std::vector<float> allocationFailures;
+
+    void update(const Cory::DeviceMemoryReportStats &stats, double nowSeconds);
+    void drawWindow(const char *title = "Device Memory Report") const;
+};
 
 }

--- a/src/Cory/Renderer/Context.cpp
+++ b/src/Cory/Renderer/Context.cpp
@@ -15,7 +15,11 @@
 #include <KDGpuKDGui/view.h>
 #include <KDGui/gui_application.h>
 
+#include <algorithm>
+#include <mutex>
 #include <stdexcept>
+
+#include <vulkan/vulkan.h>
 
 #if defined(_WIN32)
 #include <vulkan/vulkan_win32.h>
@@ -43,11 +47,21 @@ struct ContextPrivate {
     DescriptorSets descriptorSets;
     std::unique_ptr<PipelineCache> pipelineCache;
 
+    struct DeviceMemoryReportState {
+        bool enabled{false};
+        DeviceMemoryReportStats stats{};
+    };
+
+    std::mutex deviceMemoryReportMutex;
+    DeviceMemoryReportState deviceMemoryReport;
+
     inline static Function<void(const DebugMessageInfo &)> validationMessageCallback;
 
     static void receiveDebugUtilsMessage(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
                                          VkDebugUtilsMessageTypeFlagsEXT messageTypes,
                                          const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData);
+    static void deviceMemoryReportCallback(const VkDeviceMemoryReportCallbackDataEXT *pCallbackData,
+                                           void *pUserData);
 };
 
 Context::Context(ContextCreationInfo creationInfo)
@@ -186,6 +200,12 @@ Gpu::AdapterAndDevice Context::createDefaultDevice(const Gpu::Surface &surface,
     for ([[maybe_unused]] const auto &extension : adapterExtensions) {
         CO_CORE_TRACE("||  - {} Version {}", extension.name, extension.version);
     }
+    const bool supportsDeviceMemoryReport = std::any_of(
+        adapterExtensions.begin(),
+        adapterExtensions.end(),
+        [](const auto &extension) {
+            return extension.name == std::string_view{VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME};
+        });
 
     if (!supportsPresentation || !hasGraphicsAndCompute) {
         CO_CORE_FATAL("Selected adapter queue family 0 does not meet requirements. Aborting.");
@@ -217,7 +237,7 @@ Gpu::AdapterAndDevice Context::createDefaultDevice(const Gpu::Surface &surface,
     // Now we can create a device from the selected adapter that we can then use to interact
     // with the GPU.
 
-    auto device = selectedAdapter->createDevice(DeviceOptions{
+    DeviceOptions deviceOptions{
         .label = "Main Device",
         .apiVersion = KDGPU_MAKE_API_VERSION(0, 1, 3, 0),
         .layers = {},
@@ -230,7 +250,15 @@ Gpu::AdapterAndDevice Context::createDefaultDevice(const Gpu::Surface &surface,
         .requestedFeatures =
             features == DeviceFeatures::All ? selectedAdapter->features() : getRequiredFeatures(),
         .adapterGroup = {},
-    });
+    };
+
+    if (supportsDeviceMemoryReport) {
+        deviceOptions.extensions.push_back(VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME);
+        deviceOptions.deviceMemoryReportCallback = ContextPrivate::deviceMemoryReportCallback;
+        deviceOptions.deviceMemoryReportUserData = data_.get();
+    }
+
+    auto device = selectedAdapter->createDevice(deviceOptions);
 
     return {selectedAdapter, std::move(device)};
 }
@@ -287,6 +315,20 @@ void Context::setupDeviceFromSurface(const Gpu::Surface &surface)
     data_->pipelineCache = std::make_unique<PipelineCache>(
         data_->api.resourceManager(), data_->device.handle(), &data_->shaders);
 
+    {
+        const auto adapterExtensions = data_->adapter->extensions();
+        const bool supportsDeviceMemoryReport = std::any_of(
+            adapterExtensions.begin(),
+            adapterExtensions.end(),
+            [](const auto &extension) {
+                return extension.name ==
+                       std::string_view{VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME};
+            });
+        std::lock_guard lock{data_->deviceMemoryReportMutex};
+        data_->deviceMemoryReport.stats = {};
+        data_->deviceMemoryReport.enabled = supportsDeviceMemoryReport;
+    }
+
     setupDescriptors();
 }
 
@@ -327,8 +369,16 @@ void Context::setupHeadlessDevice()
         return;
     }
 
+    const auto adapterExtensions = selectedAdapter->extensions();
+    const bool supportsDeviceMemoryReport = std::any_of(
+        adapterExtensions.begin(),
+        adapterExtensions.end(),
+        [](const auto &extension) {
+            return extension.name == std::string_view{VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME};
+        });
+
     // Create device
-    auto device = selectedAdapter->createDevice(Gpu::DeviceOptions{
+    Gpu::DeviceOptions deviceOptions{
         .label = "Headless Device",
         .apiVersion = KDGPU_MAKE_API_VERSION(0, 1, 3, 0),
         .layers = {},
@@ -339,7 +389,15 @@ void Context::setupHeadlessDevice()
         .queues = {},
         .requestedFeatures = getRequiredFeatures(),
         .adapterGroup = {},
-    });
+    };
+
+    if (supportsDeviceMemoryReport) {
+        deviceOptions.extensions.push_back(VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME);
+        deviceOptions.deviceMemoryReportCallback = ContextPrivate::deviceMemoryReportCallback;
+        deviceOptions.deviceMemoryReportUserData = data_.get();
+    }
+
+    auto device = selectedAdapter->createDevice(deviceOptions);
 
     data_->adapter = selectedAdapter;
     data_->device = std::move(device);
@@ -350,6 +408,12 @@ void Context::setupHeadlessDevice()
 
     data_->pipelineCache = std::make_unique<PipelineCache>(
         data_->api.resourceManager(), data_->device.handle(), &data_->shaders);
+
+    {
+        std::lock_guard lock{data_->deviceMemoryReportMutex};
+        data_->deviceMemoryReport.stats = {};
+        data_->deviceMemoryReport.enabled = supportsDeviceMemoryReport;
+    }
 
     setupDescriptors();
 }
@@ -427,6 +491,14 @@ const FileWatchManager &Context::fileWatchManager() const
     return data_->fileWatchManager;
 }
 
+DeviceMemoryReportStats Context::deviceMemoryReportStats() const
+{
+    std::lock_guard lock{data_->deviceMemoryReportMutex};
+    DeviceMemoryReportStats stats = data_->deviceMemoryReport.stats;
+    stats.supported = data_->deviceMemoryReport.enabled;
+    return stats;
+}
+
 void ContextPrivate::receiveDebugUtilsMessage(
     VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
     VkDebugUtilsMessageTypeFlagsEXT messageTypes,
@@ -461,6 +533,71 @@ void ContextPrivate::receiveDebugUtilsMessage(
     case DebugMessageSeverity::Error:
         CO_CORE_ERROR("Vulkan Validation: {}", pCallbackData->pMessage);
         BreakpointIfDebugging();
+        break;
+    }
+}
+
+void ContextPrivate::deviceMemoryReportCallback(
+    const VkDeviceMemoryReportCallbackDataEXT *pCallbackData, void *pUserData)
+{
+    if (!pCallbackData || !pUserData) {
+        return;
+    }
+
+    auto *contextData = static_cast<ContextPrivate *>(pUserData);
+    std::lock_guard lock{contextData->deviceMemoryReportMutex};
+    auto &stats = contextData->deviceMemoryReport.stats;
+
+    const uint32_t heapIndex = pCallbackData->heapIndex;
+    if (stats.heaps.size() <= heapIndex) {
+        stats.heaps.resize(heapIndex + 1);
+        for (uint32_t index = 0; index < stats.heaps.size(); ++index) {
+            stats.heaps[index].heapIndex = index;
+        }
+    }
+    auto &heap = stats.heaps[heapIndex];
+    const uint64_t size = pCallbackData->size;
+
+    auto applyAllocation = [&](uint64_t bytes) {
+        heap.currentBytes += bytes;
+        heap.totalAllocatedBytes += bytes;
+        heap.allocationCount += 1;
+        stats.currentBytes += bytes;
+        stats.totalAllocatedBytes += bytes;
+        stats.allocationCount += 1;
+    };
+
+    auto applyFree = [&](uint64_t bytes) {
+        heap.currentBytes = heap.currentBytes >= bytes ? heap.currentBytes - bytes : 0;
+        heap.totalFreedBytes += bytes;
+        heap.freeCount += 1;
+        stats.currentBytes = stats.currentBytes >= bytes ? stats.currentBytes - bytes : 0;
+        stats.totalFreedBytes += bytes;
+        stats.freeCount += 1;
+    };
+
+    switch (pCallbackData->type) {
+    case VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_ALLOCATE_EXT:
+        applyAllocation(size);
+        break;
+    case VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_FREE_EXT:
+        applyFree(size);
+        break;
+    case VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_IMPORT_EXT:
+        applyAllocation(size);
+        heap.importCount += 1;
+        stats.importCount += 1;
+        break;
+    case VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_UNIMPORT_EXT:
+        applyFree(size);
+        heap.unimportCount += 1;
+        stats.unimportCount += 1;
+        break;
+    case VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_ALLOCATION_FAILED_EXT:
+        heap.allocationFailedCount += 1;
+        stats.allocationFailedCount += 1;
+        break;
+    default:
         break;
     }
 }

--- a/src/Cory/Renderer/Context.hpp
+++ b/src/Cory/Renderer/Context.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace Cory {
 
@@ -26,6 +27,31 @@ enum class DeviceFeatures { RequiredOnly, All };
 struct ContextCreationInfo {
     ValidationLayers validation{ValidationLayers::Enabled};
     std::span<const char *> args;
+};
+
+struct DeviceMemoryReportHeapStats {
+    uint32_t heapIndex{0};
+    uint64_t currentBytes{0};
+    uint64_t totalAllocatedBytes{0};
+    uint64_t totalFreedBytes{0};
+    uint64_t allocationCount{0};
+    uint64_t freeCount{0};
+    uint64_t importCount{0};
+    uint64_t unimportCount{0};
+    uint64_t allocationFailedCount{0};
+};
+
+struct DeviceMemoryReportStats {
+    bool supported{false};
+    uint64_t currentBytes{0};
+    uint64_t totalAllocatedBytes{0};
+    uint64_t totalFreedBytes{0};
+    uint64_t allocationCount{0};
+    uint64_t freeCount{0};
+    uint64_t importCount{0};
+    uint64_t unimportCount{0};
+    uint64_t allocationFailedCount{0};
+    std::vector<DeviceMemoryReportHeapStats> heaps;
 };
 
 /**
@@ -78,6 +104,8 @@ class Context : NoCopy {
 
     FileWatchManager &fileWatchManager();
     const FileWatchManager &fileWatchManager() const;
+
+    [[nodiscard]] DeviceMemoryReportStats deviceMemoryReportStats() const;
 
   private:
     Gpu::AdapterAndDevice


### PR DESCRIPTION
### Motivation

- Provide runtime visibility into device memory activity by enabling `VK_EXT_device_memory_report` and exposing aggregated memory metrics to the application. 
- Surface these metrics in an ImGui window that samples at a bounded interval (default 300ms) rather than querying every frame to avoid runtime overhead.

### Description

- Add data structures and a query API to `Context`: `DeviceMemoryReportHeapStats`, `DeviceMemoryReportStats`, and `Context::deviceMemoryReportStats()` to expose aggregated device memory metrics.
- Wire up a thread-safe callback `ContextPrivate::deviceMemoryReportCallback` that accumulates `VK_EXT_device_memory_report` events into the `Context` private state and mark whether the feature is enabled for the current adapter/device.
- Add a small KDGpu patch (applied via `external/patches/kdgpu-device-memory-report.patch`) and make `external/CMakeLists.txt` invoke it so KDGpu will attach the device memory report create-info and enable the feature when available during device creation (uses new `DeviceOptions` fields `deviceMemoryReportCallback` and `deviceMemoryReportUserData`).
- Implement `CoImGui::DeviceMemoryReportHistory` (in `src/Cory/ImGui/Widgets.hpp` / `.cpp`) which keeps a time-series (default sample interval `0.3` seconds) and renders current/total/alloc counts and per-heap tables and plots, and intentionally avoids sampling every frame.
- Integrate the ImGui window into the samples (excluding HelloTriangle) alongside the existing profiling window by calling `memoryReportHistory_.update(ctx().deviceMemoryReportStats(), <time>)` and `memoryReportHistory_.drawWindow()` in these demos: `examples/02-CubeDemo`, `examples/03-SceneGraph`, `examples/04-DynamicPipeline`, and `examples/05-ParticleCompute`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2257309c83279b1b115bb900d52f)