### PR TITLE
Add ECS SystemScheduler, resource-access ADR, and unit tests

### DIFF
--- a/ADR-07-ecs-script-execution.md
+++ b/ADR-07-ecs-script-execution.md
@@ -1,0 +1,334 @@
+# ADR-07: ECS Script Execution and Resource-Access Scheduling
+
+## Status
+Draft design notes
+
+## Context
+Cory already uses a framegraph-style model for renderer work: tasks declare resource access, the engine derives ordering, and runtime execution can be separated from user-authored task order. The same model is a good fit for future gameplay and scripting work.
+
+The goal for the ECS/script layer is to keep gameplay code simple while giving the engine enough information to safely schedule work automatically. Systems and scripts should declare what they read and write; they should not rely on arbitrary source-registration order for correctness.
+
+Primary goals:
+1. Keep gameplay and script code natural to author.
+2. Allow automatic parallel execution whenever access declarations prove it is safe.
+3. Avoid manual scheduling by ECS users.
+4. Scale from a single-threaded implementation to many-core systems.
+5. Support deterministic execution.
+6. Provide a foundation that can later integrate with the renderer framegraph and a general task graph.
+
+## Decision
+Model ECS component state, script-visible engine state, and future renderer resources as resources with declared read/write access.
+
+Each ECS system declares the component and engine resources it reads and writes. The engine gathers those declarations, derives dependencies, constructs a directed acyclic execution graph, and executes the graph in a deterministic topological order initially. Later phases can execute independent graph nodes on a thread pool.
+
+Conceptually, ECS scheduling should follow the same producer/consumer model as the render framegraph:
+
+```text
+Resource + Read/Write Access + Dependency Analysis + Task Scheduling
+```
+
+Rendering resources include textures, buffers, and acceleration structures. Gameplay resources include components, entity state, input state, time, and simulation state.
+
+## ECS Authoring Model
+A system should express data access through its function signature or explicit registration metadata.
+
+Example system:
+
+```cpp
+struct MoveSystem
+{
+    void update(Transform &transform, const Velocity &velocity)
+    {
+        transform.position += velocity.value;
+    }
+};
+```
+
+This implies:
+1. `Velocity` is read.
+2. `Transform` is written.
+
+An initial explicit registration API can make this contract clear before investing in signature reflection or generated metadata:
+
+```cpp
+register_system<MovementSystem>({
+    read<Velocity>(),
+    write<Transform>(),
+});
+```
+
+## Access Model
+Use a minimal read/write access model first:
+
+```cpp
+enum class Access
+{
+    Read,
+    Write,
+};
+
+struct ResourceAccess
+{
+    ResourceId resource;
+    Access access;
+};
+
+struct SystemDescription
+{
+    std::vector<ResourceAccess> accesses;
+};
+```
+
+A system that reads velocity and input while writing transforms would declare:
+
+```text
+Movement
+    Reads:  Velocity, InputState
+    Writes: Transform
+```
+
+## Dependency Rules
+Dependencies are derived per resource:
+
+| Prior access | Later access | Concurrent? | Dependency required? |
+| --- | --- | --- | --- |
+| Read | Read | Yes | No |
+| Read | Write | No | Yes |
+| Write | Read | No | Yes |
+| Write | Write | No | Yes |
+
+Read-only sharing scales well. Many systems may read the same component or simulation resource concurrently. Writes are the serialization points.
+
+## Dependency Graph Construction
+For every registered system, gather metadata:
+
+```cpp
+struct SystemMetadata
+{
+    ResourceSet reads;
+    ResourceSet writes;
+};
+```
+
+Given:
+
+```text
+Movement
+    Reads:  Velocity
+    Writes: Transform
+Animation
+    Reads:  Transform
+    Writes: Skeleton
+Renderer
+    Reads:  Transform, Skeleton
+```
+
+The dependency graph is:
+
+```text
+Movement --> Animation --> Renderer
+Movement ------------------> Renderer
+```
+
+This graph follows from resource flow:
+
+```text
+Velocity  ---> Movement ---> Transform
+Transform ---> Animation ---> Skeleton
+Skeleton  ------------------> Renderer
+Transform ------------------> Renderer
+```
+
+The engine should then topologically sort the graph. Independent systems at the same dependency depth can later become parallel work items.
+
+## Parallel Execution Example
+Given:
+
+```text
+Movement
+    Writes: Transform
+Damage
+    Writes: Health
+Audio
+    Reads: Transform, Health
+```
+
+`Movement` and `Damage` are independent because they touch different resources. `Audio` depends on both because it reads the resources they write.
+
+```text
+Movement ----+
+             v
+            Audio
+             ^
+Damage ------+
+```
+
+A thread-pool scheduler may run `Movement` and `Damage` concurrently, then run `Audio` after both complete.
+
+## Task Graph Generation Pipeline
+The intended runtime pipeline is:
+
+```text
+Registered Systems
+    -> Access Metadata
+    -> Dependency Graph
+    -> Task Graph
+    -> Execution Backend
+```
+
+The execution backend can begin as a single-threaded topological traversal and later become a DAG executor backed by `std::execution`, Taskflow, enkiTS, or a Cory-specific scheduler.
+
+## Recommended Implementation Phases
+
+### Phase 1: Single-Threaded Validation
+1. Add `ResourceId`, `ResourceAccess`, `SystemDescription`, and system registration metadata.
+2. Gather all system read/write declarations.
+3. Validate declarations and detect graph cycles.
+4. Execute systems single-threaded in derived topological order.
+5. Keep deterministic tie-breaking for nodes with no dependency relation.
+
+### Phase 2: DAG Scheduling
+1. Build an explicit DAG with system nodes and dependency edges.
+2. Persist diagnostics that explain why each edge exists.
+3. Topologically sort the DAG per frame or per schedule rebuild.
+4. Rebuild only when system/resource metadata changes.
+
+### Phase 3: Parallel Execution
+1. Submit ready DAG nodes to a thread pool.
+2. Track dependency counters for each node.
+3. Enqueue dependents as their incoming counters reach zero.
+4. Preserve deterministic behavior through stable graph construction, deterministic tie-breaking, and explicit synchronization points.
+
+### Phase 4: Fine-Grained Resources
+Start conservatively with component types as global resources:
+
+```text
+Resource = Component Type
+```
+
+Then move to finer-grained resources where profitable:
+
+```text
+Resource = (Entity, Component)
+```
+
+or:
+
+```text
+Resource = (Archetype Chunk, Component)
+```
+
+The type-level model is conservative because all writes to `Transform` serialize. Entity- or chunk-level resources allow unrelated entities to update concurrently while still tracking cross-entity dependencies.
+
+## Cross-Entity Dependencies
+Fine-grained scheduling must support scripts that access other entities.
+
+Example:
+
+```text
+EnemyScript
+    Reads:  Player.Transform
+    Writes: Enemy.Transform
+```
+
+If another system writes `Player.Transform`, the enemy script depends on that writer:
+
+```text
+Player Update --> EnemyScript
+```
+
+This is the same resource dependency rule applied to a more precise resource key.
+
+## Determinism Requirements
+The scheduler should be deterministic by construction:
+
+1. Stable system identifiers.
+2. Stable resource identifiers.
+3. Stable tie-breaking for otherwise independent systems.
+4. Explicit schedule rebuild points.
+5. Diagnostics for dependency edges and cycles.
+6. Clear constraints around side effects such as random number generation, input snapshots, event queues, and external I/O.
+
+Parallel execution should not change observable results compared to the single-threaded topological schedule. If a system performs side effects outside declared resources, it must declare a resource for that side effect or be isolated in a serialized phase.
+
+## Relationship to the Framegraph
+The ECS scheduler and renderer framegraph should converge conceptually. Both systems are resource graphs:
+
+| Domain | Resources | Tasks |
+| --- | --- | --- |
+| Rendering | Textures, buffers, acceleration structures | Render and compute passes |
+| Gameplay | Components, entity state, input, time, physics state | ECS systems and scripts |
+
+Long term, both domains can feed a unified task-graph-driven engine architecture. Gameplay systems and render passes become producers and consumers with explicit resource access declarations, allowing the runtime to derive ordering, synchronization, and parallelism.
+
+## Non-Goals for the Initial Pass
+1. Full reflection-based system registration.
+2. Entity-level or chunk-level dependency precision.
+3. Lock-free component storage.
+4. A custom high-performance work-stealing scheduler.
+5. Integration with renderer pass execution in the first implementation.
+6. Hot-reloadable scripting language support.
+
+## Open Questions
+1. Should explicit registration remain the long-term API, or should it be generated from system function signatures?
+2. Should resources be represented by component type IDs, stable strings, or typed handles?
+3. How should command/event buffers declare reads and writes?
+4. How should the scheduler expose diagnostics to tests and debug UI?
+5. Which external DAG executor, if any, fits Cory's coroutine-heavy architecture best?
+6. What is the right boundary between deterministic gameplay scheduling and opportunistic renderer scheduling?
+
+## Implementation Sketch
+
+```cpp
+enum class Access
+{
+    Read,
+    Write,
+};
+
+struct ResourceAccess
+{
+    ResourceId resource;
+    Access access;
+};
+
+struct SystemDescription
+{
+    std::string_view name;
+    std::vector<ResourceAccess> accesses;
+};
+
+class SystemScheduler
+{
+public:
+    void registerSystem(SystemDescription description);
+    void rebuildSchedule();
+    void execute(World &world);
+};
+```
+
+Initial execution can be deliberately simple:
+
+```text
+1. Gather systems.
+2. Build dependency graph from read/write metadata.
+3. Topologically sort graph.
+4. Execute sorted systems single-threaded.
+5. Emit diagnostics for dependency edges.
+```
+
+This creates the correctness foundation before introducing parallelism.
+
+## Consequences
+Positive:
+1. Gameplay code remains focused on data transformations.
+2. The engine owns ordering and synchronization.
+3. The first implementation can be deterministic and single-threaded.
+4. The same declarations enable later parallel execution.
+5. The model aligns with Cory's existing framegraph direction.
+
+Tradeoffs:
+1. Conservative component-type resources may serialize more work than necessary.
+2. Users must declare access accurately.
+3. Dependency diagnostics become essential for debuggability.
+4. Side effects must be modeled explicitly to preserve determinism.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ As such, it uses features that are only supported in rather modern compilers.
     - [ ] use std::pmr based allocator for Vulkan API calls
 - GameObject/Scenegraph system (Entities + Components, not full data-drive ECS)
     - [ ] basic entity/component system
+    - [ ] ECS/script execution scheduler design ([ADR-07](ADR-07-ecs-script-execution.md))
 - Shader System
     - [x] push constants
     - [x] On-the fly shader compilation using [Slang](https://github.com/shader-slang/slang)

--- a/src/Cory/CMakeLists.txt
+++ b/src/Cory/CMakeLists.txt
@@ -97,6 +97,9 @@ set(CORY_SOURCES
         Base/WorkContractGroup.hpp
         Cory.cpp
         Cory.hpp
+        Ecs/Common.hpp
+        Ecs/SystemScheduler.cpp
+        Ecs/SystemScheduler.hpp
         Framegraph/Builder.cpp
         Framegraph/Common.hpp
         Framegraph/Framegraph.cpp

--- a/src/Cory/Ecs/Common.hpp
+++ b/src/Cory/Ecs/Common.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
+
+namespace Cory::Ecs {
+
+struct Entity {
+    uint32_t value{0};
+
+    friend bool operator==(Entity, Entity) = default;
+};
+
+struct ResourceId {
+    std::string name;
+
+    ResourceId() = default;
+    explicit ResourceId(std::string_view resourceName)
+        : name(resourceName)
+    {
+    }
+
+    friend bool operator==(const ResourceId &, const ResourceId &) = default;
+    friend auto operator<=>(const ResourceId &, const ResourceId &) = default;
+};
+
+template <typename T> ResourceId resource()
+{
+    return ResourceId{typeid(std::remove_cvref_t<T>).name()};
+}
+
+inline ResourceId resource(std::string_view name)
+{
+    return ResourceId{name};
+}
+
+enum class Access {
+    Read,
+    Write,
+};
+
+struct ResourceAccess {
+    ResourceId resource;
+    Access access{Access::Read};
+
+    friend bool operator==(const ResourceAccess &, const ResourceAccess &) = default;
+};
+
+inline ResourceAccess read(ResourceId id)
+{
+    return ResourceAccess{std::move(id), Access::Read};
+}
+inline ResourceAccess write(ResourceId id)
+{
+    return ResourceAccess{std::move(id), Access::Write};
+}
+
+template <typename T> ResourceAccess read()
+{
+    return read(resource<T>());
+}
+
+template <typename T> ResourceAccess write()
+{
+    return write(resource<T>());
+}
+
+using SystemFn = std::function<void()>;
+
+} // namespace Cory::Ecs

--- a/src/Cory/Ecs/SystemScheduler.cpp
+++ b/src/Cory/Ecs/SystemScheduler.cpp
@@ -1,0 +1,203 @@
+#include <Cory/Ecs/SystemScheduler.hpp>
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <queue>
+#include <set>
+#include <sstream>
+#include <utility>
+
+namespace Cory::Ecs {
+namespace {
+
+using AccessMap = std::map<ResourceId, Access>;
+
+Access strongestAccess(Access lhs, Access rhs)
+{
+    if (lhs == Access::Write || rhs == Access::Write) {
+        return Access::Write;
+    }
+    return Access::Read;
+}
+
+AccessMap effectiveAccesses(const SystemDescription &description)
+{
+    AccessMap result;
+    for (const ResourceAccess &access : description.accesses) {
+        auto [it, inserted] = result.emplace(access.resource, access.access);
+        if (!inserted) {
+            it->second = strongestAccess(it->second, access.access);
+        }
+    }
+    return result;
+}
+
+bool conflicts(Access previous, Access current)
+{
+    return previous == Access::Write || current == Access::Write;
+}
+
+} // namespace
+
+SystemHandle SystemScheduler::registerSystem(SystemDescription description, SystemFn fn)
+{
+    const SystemHandle handle{systems_.size()};
+    if (description.name.empty()) {
+        description.name = "System " + std::to_string(handle.index);
+    }
+    systems_.push_back(SystemEntry{std::move(description), std::move(fn)});
+    scheduleDirty_ = true;
+    return handle;
+}
+
+void SystemScheduler::clear()
+{
+    systems_.clear();
+    executionOrder_.clear();
+    executionBatches_.clear();
+    dependencyEdges_.clear();
+    scheduleDirty_ = false;
+}
+
+void SystemScheduler::rebuildSchedule()
+{
+    dependencyEdges_.clear();
+    executionOrder_.clear();
+    executionBatches_.clear();
+
+    const size_t systemCount = systems_.size();
+    std::vector<std::set<size_t>> outgoing(systemCount);
+    std::vector<size_t> incomingCount(systemCount, 0);
+
+    struct ResourceState {
+        std::vector<std::pair<SystemHandle, Access>> readers;
+        std::optional<std::pair<SystemHandle, Access>> writer;
+    };
+    std::map<ResourceId, ResourceState> resourceStates;
+
+    auto addEdge = [&](SystemHandle before,
+                       SystemHandle after,
+                       const ResourceId &resource,
+                       Access beforeAccess,
+                       Access afterAccess) {
+        if (before == after) {
+            return;
+        }
+        auto [_, inserted] = outgoing[before.index].insert(after.index);
+        if (inserted) {
+            ++incomingCount[after.index];
+        }
+        dependencyEdges_.push_back(
+            DependencyEdge{before, after, resource, beforeAccess, afterAccess});
+    };
+
+    for (size_t systemIndex = 0; systemIndex < systemCount; ++systemIndex) {
+        const SystemHandle current{systemIndex};
+        const AccessMap accesses = effectiveAccesses(systems_[systemIndex].description);
+
+        for (const auto &[resource, currentAccess] : accesses) {
+            ResourceState &state = resourceStates[resource];
+            if (state.writer.has_value() && conflicts(state.writer->second, currentAccess)) {
+                addEdge(
+                    state.writer->first, current, resource, state.writer->second, currentAccess);
+            }
+
+            if (currentAccess == Access::Write) {
+                for (const auto &[reader, readerAccess] : state.readers) {
+                    addEdge(reader, current, resource, readerAccess, currentAccess);
+                }
+                state.readers.clear();
+                state.writer = std::pair{current, currentAccess};
+            }
+            else {
+                state.readers.push_back(std::pair{current, currentAccess});
+            }
+        }
+    }
+
+    std::priority_queue<size_t, std::vector<size_t>, std::greater<>> ready;
+    for (size_t i = 0; i < systemCount; ++i) {
+        if (incomingCount[i] == 0) {
+            ready.push(i);
+        }
+    }
+
+    while (!ready.empty()) {
+        const size_t batchSize = ready.size();
+        std::vector<SystemHandle> batch;
+        batch.reserve(batchSize);
+
+        std::vector<size_t> currentBatch;
+        currentBatch.reserve(batchSize);
+        for (size_t i = 0; i < batchSize; ++i) {
+            currentBatch.push_back(ready.top());
+            ready.pop();
+        }
+
+        for (const size_t systemIndex : currentBatch) {
+            executionOrder_.push_back(SystemHandle{systemIndex});
+            batch.push_back(SystemHandle{systemIndex});
+
+            for (const size_t dependent : outgoing[systemIndex]) {
+                --incomingCount[dependent];
+                if (incomingCount[dependent] == 0) {
+                    ready.push(dependent);
+                }
+            }
+        }
+
+        executionBatches_.push_back(std::move(batch));
+    }
+
+    if (executionOrder_.size() != systemCount) {
+        std::ostringstream message;
+        message << "ECS system dependency graph contains a cycle; scheduled "
+                << executionOrder_.size() << " of " << systemCount << " systems";
+        throw ScheduleCycleError{message.str()};
+    }
+
+    scheduleDirty_ = false;
+}
+
+void SystemScheduler::execute()
+{
+    ensureScheduleCurrent();
+    for (const SystemHandle handle : executionOrder_) {
+        if (systems_[handle.index].fn) {
+            systems_[handle.index].fn();
+        }
+    }
+}
+
+const SystemDescription &SystemScheduler::description(SystemHandle handle) const
+{
+    return systems_.at(handle.index).description;
+}
+
+const std::vector<SystemHandle> &SystemScheduler::executionOrder() const
+{
+    const_cast<SystemScheduler *>(this)->ensureScheduleCurrent();
+    return executionOrder_;
+}
+
+const std::vector<std::vector<SystemHandle>> &SystemScheduler::executionBatches() const
+{
+    const_cast<SystemScheduler *>(this)->ensureScheduleCurrent();
+    return executionBatches_;
+}
+
+const std::vector<DependencyEdge> &SystemScheduler::dependencyEdges() const
+{
+    const_cast<SystemScheduler *>(this)->ensureScheduleCurrent();
+    return dependencyEdges_;
+}
+
+void SystemScheduler::ensureScheduleCurrent()
+{
+    if (scheduleDirty_) {
+        rebuildSchedule();
+    }
+}
+
+} // namespace Cory::Ecs

--- a/src/Cory/Ecs/SystemScheduler.hpp
+++ b/src/Cory/Ecs/SystemScheduler.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <Cory/Ecs/Common.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace Cory::Ecs {
+
+struct SystemHandle {
+    size_t index{static_cast<size_t>(-1)};
+
+    friend bool operator==(SystemHandle, SystemHandle) = default;
+};
+
+struct SystemDescription {
+    std::string name;
+    std::vector<ResourceAccess> accesses;
+};
+
+struct DependencyEdge {
+    SystemHandle before;
+    SystemHandle after;
+    ResourceId resource;
+    Access beforeAccess{Access::Read};
+    Access afterAccess{Access::Read};
+};
+
+class ScheduleCycleError : public std::runtime_error {
+  public:
+    explicit ScheduleCycleError(const std::string &message)
+        : std::runtime_error(message)
+    {
+    }
+};
+
+class SystemScheduler {
+  public:
+    SystemHandle registerSystem(SystemDescription description, SystemFn fn);
+
+    void clear();
+    void rebuildSchedule();
+    void execute();
+
+    [[nodiscard]] bool scheduleDirty() const noexcept { return scheduleDirty_; }
+    [[nodiscard]] const SystemDescription &description(SystemHandle handle) const;
+    [[nodiscard]] const std::vector<SystemHandle> &executionOrder() const;
+    [[nodiscard]] const std::vector<std::vector<SystemHandle>> &executionBatches() const;
+    [[nodiscard]] const std::vector<DependencyEdge> &dependencyEdges() const;
+
+  private:
+    struct SystemEntry {
+        SystemDescription description;
+        SystemFn fn;
+    };
+
+    void ensureScheduleCurrent();
+
+    std::vector<SystemEntry> systems_;
+    std::vector<SystemHandle> executionOrder_;
+    std::vector<std::vector<SystemHandle>> executionBatches_;
+    std::vector<DependencyEdge> dependencyEdges_;
+    bool scheduleDirty_{false};
+};
+
+} // namespace Cory::Ecs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(Cory_TestLib OBJECT
         MappedCoherentDeviceBuffer_Test.cpp
         AsyncUploader_Test.cpp
         ApiPass_Test.cpp
+        EcsSystemScheduler_Test.cpp
         DatasetLoader_Test.cpp
         CppcoroConcurrency_Test.cpp
 )

--- a/tests/EcsSystemScheduler_Test.cpp
+++ b/tests/EcsSystemScheduler_Test.cpp
@@ -1,0 +1,107 @@
+#include <Cory/Ecs/SystemScheduler.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+using namespace Cory::Ecs;
+
+namespace {
+struct Transform {};
+struct Velocity {};
+struct Health {};
+struct Skeleton {};
+} // namespace
+
+TEST_CASE("ECS scheduler runs independent systems in registration order")
+{
+    SystemScheduler scheduler;
+    std::vector<std::string> calls;
+
+    const SystemHandle movement = scheduler.registerSystem(
+        SystemDescription{.name = "Movement", .accesses = {read<Velocity>(), write<Transform>()}},
+        [&] { calls.push_back("Movement"); });
+    const SystemHandle damage =
+        scheduler.registerSystem(SystemDescription{.name = "Damage", .accesses = {write<Health>()}},
+                                 [&] { calls.push_back("Damage"); });
+
+    scheduler.execute();
+
+    CHECK(calls == std::vector<std::string>{"Movement", "Damage"});
+    REQUIRE(scheduler.executionBatches().size() == 1);
+    CHECK(scheduler.executionBatches()[0] == std::vector<SystemHandle>{movement, damage});
+    CHECK(scheduler.dependencyEdges().empty());
+}
+
+TEST_CASE("ECS scheduler serializes read write component conflicts")
+{
+    SystemScheduler scheduler;
+    std::vector<std::string> calls;
+
+    const SystemHandle movement = scheduler.registerSystem(
+        SystemDescription{.name = "Movement", .accesses = {read<Velocity>(), write<Transform>()}},
+        [&] { calls.push_back("Movement"); });
+    const SystemHandle animation = scheduler.registerSystem(
+        SystemDescription{.name = "Animation", .accesses = {read<Transform>(), write<Skeleton>()}},
+        [&] { calls.push_back("Animation"); });
+    const SystemHandle renderPrep = scheduler.registerSystem(
+        SystemDescription{.name = "RenderPrep", .accesses = {read<Transform>(), read<Skeleton>()}},
+        [&] { calls.push_back("RenderPrep"); });
+
+    scheduler.execute();
+
+    CHECK(calls == std::vector<std::string>{"Movement", "Animation", "RenderPrep"});
+    CHECK(scheduler.executionOrder() == std::vector<SystemHandle>{movement, animation, renderPrep});
+    const auto &edges = scheduler.dependencyEdges();
+    REQUIRE(edges.size() == 3);
+    const auto containsEdge = [&](SystemHandle before, SystemHandle after, ResourceId resource) {
+        return std::ranges::any_of(edges, [&](const DependencyEdge &edge) {
+            return edge.before == before && edge.after == after && edge.resource == resource;
+        });
+    };
+    CHECK(containsEdge(movement, animation, resource<Transform>()));
+    CHECK(containsEdge(movement, renderPrep, resource<Transform>()));
+    CHECK(containsEdge(animation, renderPrep, resource<Skeleton>()));
+}
+
+TEST_CASE("ECS scheduler exposes parallel batches for independent predecessors")
+{
+    SystemScheduler scheduler;
+
+    const SystemHandle movement = scheduler.registerSystem(
+        SystemDescription{.name = "Movement", .accesses = {write<Transform>()}}, [] {});
+    const SystemHandle damage = scheduler.registerSystem(
+        SystemDescription{.name = "Damage", .accesses = {write<Health>()}}, [] {});
+    const SystemHandle audio = scheduler.registerSystem(
+        SystemDescription{.name = "Audio", .accesses = {read<Transform>(), read<Health>()}}, [] {});
+
+    scheduler.rebuildSchedule();
+
+    REQUIRE(scheduler.executionBatches().size() == 2);
+    CHECK(scheduler.executionBatches()[0] == std::vector<SystemHandle>{movement, damage});
+    CHECK(scheduler.executionBatches()[1] == std::vector<SystemHandle>{audio});
+    REQUIRE(scheduler.dependencyEdges().size() == 2);
+    CHECK(scheduler.dependencyEdges()[0].after == audio);
+    CHECK(scheduler.dependencyEdges()[1].after == audio);
+}
+
+TEST_CASE("ECS scheduler treats duplicate read write declarations as writes")
+{
+    SystemScheduler scheduler;
+
+    const ResourceId transform = resource("Transform");
+    const SystemHandle integrator = scheduler.registerSystem(
+        SystemDescription{.name = "Integrator", .accesses = {read(transform), write(transform)}},
+        [] {});
+    const SystemHandle observer = scheduler.registerSystem(
+        SystemDescription{.name = "Observer", .accesses = {read(transform)}}, [] {});
+
+    scheduler.rebuildSchedule();
+
+    CHECK(scheduler.executionOrder() == std::vector<SystemHandle>{integrator, observer});
+    REQUIRE(scheduler.dependencyEdges().size() == 1);
+    CHECK(scheduler.dependencyEdges()[0].beforeAccess == Access::Write);
+    CHECK(scheduler.dependencyEdges()[0].afterAccess == Access::Read);
+}


### PR DESCRIPTION
### Motivation
- Introduce a resource-based scheduling model for ECS/scripting so systems can declare read/write accesses and the engine can derive safe ordering and parallelism. 
- Provide a deterministic, testable foundation that can later converge with the renderer framegraph and be extended to parallel execution. 

### Description
- Add an ADR `ADR-07-ecs-script-execution.md` describing the design and phased implementation plan for resource-access scheduling. 
- Implement core ECS types and helpers in `src/Cory/Ecs/Common.hpp` including `ResourceId`, `Access`, `ResourceAccess`, and helpers `read`/`write`/`resource`. 
- Implement `SystemScheduler` in `src/Cory/Ecs/SystemScheduler.hpp` and `.cpp` with `registerSystem`, `rebuildSchedule`, `execute`, dependency edge construction, cycle detection via `ScheduleCycleError`, and exposure of `executionOrder`, `executionBatches`, and `dependencyEdges`. 
- Wire new sources and tests into the build (`src/Cory/CMakeLists.txt`, `tests/CMakeLists.txt`), update `README.md` to reference the ADR, and add test file `tests/EcsSystemScheduler_Test.cpp` covering scheduling scenarios. 

### Testing
- Added `EcsSystemScheduler_Test.cpp` with tests for independent-system ordering, read/write conflict serialization, parallel batches, and duplicate access handling. 
- Built the project and ran the unit test suite including the new `EcsSystemScheduler_Test`, and the tests succeeded. 
- The scheduler throws `ScheduleCycleError` on cycles and exposes deterministic batches and dependency diagnostics verified by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a215e0b3f988327a9e274c50a4c9978)